### PR TITLE
vinyl-digitizer dark mode, steps redo

### DIFF
--- a/app/(main)/YouTubeAuth/YouTubeAuth.js
+++ b/app/(main)/YouTubeAuth/YouTubeAuth.js
@@ -15,6 +15,9 @@ function YouTubeAuth({ compact = false, returnUrl = '/youtube', onAuthStateChang
   const [clearAuthLoading, setClearAuthLoading] = useState(false);
   const [error, setError] = useState('');
   const [debugLog, setDebugLog] = useState([]);
+  // 'unknown' | 'checking' | 'valid' | 'invalid'
+  const [tokenValidity, setTokenValidity] = useState('unknown');
+  const [tokenValidityReason, setTokenValidityReason] = useState('');
   const [youtubeAuthStatus, setYoutubeAuthStatus] = useState({
     exists: false,
     code: null,
@@ -23,11 +26,15 @@ function YouTubeAuth({ compact = false, returnUrl = '/youtube', onAuthStateChang
     expiresAt: null,
   });
 
-  const canAuth =
+  // Only show signed-in once tokens have been verified against Google.
+  // If verification hasn't completed yet, we treat the user as signed-out so
+  // they can't attempt an upload that will fail with invalid_grant.
+  const hasLocalAuth =
     isAuthenticated ||
     (youtubeAuthStatus.exists &&
       youtubeAuthStatus.expiresAt &&
       new Date(youtubeAuthStatus.expiresAt) > new Date());
+  const canAuth = hasLocalAuth && tokenValidity === 'valid';
 
   const addDebugLog = (msg, type = 'info') => {
     setDebugLog(prev => [...prev, { msg, type, time: new Date().toLocaleTimeString() }]);
@@ -147,6 +154,8 @@ function YouTubeAuth({ compact = false, returnUrl = '/youtube', onAuthStateChang
       k => localStorage.removeItem(k)
     );
     setYoutubeAuthStatus({ exists: false, code: null, scope: null, setTime: null, expiresAt: null });
+    setTokenValidity('unknown');
+    setTokenValidityReason('');
     getYouTubeAuthUrl();
     setClearAuthLoading(false);
   };
@@ -158,28 +167,133 @@ function YouTubeAuth({ compact = false, returnUrl = '/youtube', onAuthStateChang
     addDebugLog('Cleared stored tokens. Will re-exchange code on next attempt.', 'info');
   };
 
-  // Initiate sign-in — store returnUrl first so /youtube can redirect back
+  // Initiate sign-in — open in a new tab so the user keeps their current page state.
+  // The new tab handles the OAuth round-trip and writes the resulting auth code to
+  // localStorage; this tab listens for that change via the `storage` event and
+  // re-runs token verification automatically.
   const handleSignIn = () => {
     if (!authUrl || authUrlLoading) return;
-    if (returnUrl && returnUrl !== '/youtube') {
-      localStorage.setItem('youtube_auth_return_url', returnUrl);
+    // Hint to the callback page that it was opened in a popup-style tab
+    try { localStorage.setItem('youtube_auth_popup_flow', '1'); } catch {}
+    const w = window.open(authUrl, '_blank', 'noopener,noreferrer');
+    if (!w) {
+      // Popup blocked — fall back to in-page redirect with returnUrl behavior
+      if (returnUrl && returnUrl !== '/youtube') {
+        try { localStorage.setItem('youtube_auth_return_url', returnUrl); } catch {}
+      }
+      window.location.href = authUrl;
     }
-    window.location.href = authUrl;
   };
 
-  // Mount: read localStorage, check server, fetch auth URL
+  // Verify cached tokens actually work against Google (catches invalid_grant
+  // before the user attempts an upload).
+  const verifyTokens = async () => {
+    setTokenValidity('checking');
+    setTokenValidityReason('');
+    // 1. Read any cached tokens from localStorage.
+    let storedTokens = null;
+    try {
+      const raw = localStorage.getItem('youtube_tokens');
+      if (raw) storedTokens = JSON.parse(raw);
+    } catch {}
+    // 2. If no tokens yet but we have an unexchanged auth code, exchange it.
+    //    This is the normal post-OAuth state: callback stored the code but
+    //    nothing has called /exchangeCode yet.
+    let exchangeFailed = false;
+    if (!storedTokens?.access_token && !storedTokens?.refresh_token) {
+      const hasCode = !!localStorage.getItem('youtube_auth_code');
+      if (hasCode) {
+        addDebugLog('No stored tokens — exchanging auth code for tokens before verification…', 'info');
+        const exchanged = await getTokens();
+        if (exchanged?.access_token || exchanged?.refresh_token) {
+          storedTokens = exchanged;
+        } else {
+          exchangeFailed = true;
+        }
+      }
+    }
+    if (exchangeFailed) {
+      setTokenValidity('invalid');
+      setTokenValidityReason('exchange_failed');
+      addDebugLog('Token exchange failed — auth code was rejected.', 'error');
+      return false;
+    }
+    try {
+      const res = await fetch(`${apiBaseURL()}/youtube/validateTokens`, {
+        method: 'POST',
+        headers: { 'Content-Type': 'application/json' },
+        credentials: 'include',
+        body: JSON.stringify({ tokens: storedTokens || undefined }),
+      });
+      const data = await res.json().catch(() => ({}));
+      if (data?.valid) {
+        setTokenValidity('valid');
+        setTokenValidityReason('');
+        return true;
+      }
+      setTokenValidity('invalid');
+      setTokenValidityReason(data?.reason || 'unknown');
+      addDebugLog(`Token verification failed: ${data?.reason || 'unknown'}`, 'warn');
+      return false;
+    } catch (err) {
+      // Network failure — don't lock the user out, but flag as unknown.
+      setTokenValidity('unknown');
+      setTokenValidityReason(err?.message || 'network_error');
+      addDebugLog(`Token verification network error: ${err?.message}`, 'warn');
+      return false;
+    }
+  };
+
+  // Mount: read localStorage, check server, fetch auth URL, validate tokens
   useEffect(() => {
-    refreshLocalAuthStatus();
+    const status = refreshLocalAuthStatus();
     checkAuthStatus();
     getYouTubeAuthUrl();
+    // Only verify if we actually have something to verify
+    if (status.exists) {
+      verifyTokens();
+    } else {
+      setTokenValidity('unknown');
+    }
   }, []);
+
+  // Re-verify when the server confirms a session is authenticated but we
+  // haven't validated yet (e.g., session cookie present without localStorage).
+  useEffect(() => {
+    if (isAuthenticated && tokenValidity === 'unknown') verifyTokens();
+  }, [isAuthenticated]);
+
+  // Listen for the OAuth-callback tab to publish a fresh auth code. When it
+  // does, refresh local state and re-verify so this tab updates without a reload.
+  useEffect(() => {
+    const onStorage = (e) => {
+      if (!e || e.storageArea !== window.localStorage) return;
+      if (e.key === 'youtube_auth_code' || e.key === 'youtube_tokens') {
+        // A sibling tab updated YouTube credentials — refresh and re-validate.
+        const status = refreshLocalAuthStatus();
+        addDebugLog(`Detected auth update from another tab (${e.key}) — re-verifying…`, 'info');
+        if (status.exists || e.key === 'youtube_tokens') {
+          verifyTokens();
+        }
+      }
+    };
+    window.addEventListener('storage', onStorage);
+    return () => window.removeEventListener('storage', onStorage);
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  // Expose verifyTokens via ref so the upload flow can re-check on demand
+  useEffect(() => {
+    if (getTokensRef && getTokensRef.current) {
+      getTokensRef.current.verifyTokens = verifyTokens;
+    }
+  });
 
   // Notify parent when auth state changes
   useEffect(() => {
     if (onAuthStateChange) {
-      onAuthStateChange({ isAuthenticated, youtubeAuthStatus, canAuth });
+      onAuthStateChange({ isAuthenticated, youtubeAuthStatus, canAuth, tokenValidity, tokenValidityReason });
     }
-  }, [isAuthenticated, youtubeAuthStatus.exists, canAuth]);
+  }, [isAuthenticated, youtubeAuthStatus.exists, canAuth, tokenValidity, tokenValidityReason]);
 
   // ---------- COMPACT MODE ----------
   if (compact) {
@@ -187,11 +301,26 @@ function YouTubeAuth({ compact = false, returnUrl = '/youtube', onAuthStateChang
     const signedInColor = (blackTextOnWhite || darkMode) ? textColor : '#155724';
     const notSignedInColor = (blackTextOnWhite || darkMode) ? textColor : '#721c24';
     const errorColor = (blackTextOnWhite || darkMode) ? textColor : '#721c24';
+    const reasonLabel = (() => {
+      const r = (tokenValidityReason || '').toLowerCase();
+      if (r.includes('invalid_grant')) return 'Your YouTube sign-in expired or was revoked.';
+      if (r.includes('exchange_failed')) return 'The OAuth code returned by Google could not be exchanged for tokens. The code may have already been used or expired.';
+      if (r.includes('no_tokens')) return 'Your sign-in did not produce any usable tokens. This usually means the OAuth code expired before exchange — please sign in again.';
+      if (r.includes('oauth_client')) return 'YouTube OAuth is not configured on the server.';
+      if (r.includes('network')) return 'Could not reach the server to verify your YouTube sign-in.';
+      if (tokenValidityReason) return `YouTube sign-in problem: ${tokenValidityReason}`;
+      return '';
+    })();
+
+    // Show the expired/invalid state when we have local auth but verification failed
+    const showInvalidBanner = hasLocalAuth && tokenValidity === 'invalid';
+    const isChecking = hasLocalAuth && tokenValidity === 'checking';
+
     return (
       <div style={{ display: 'flex', alignItems: 'center', gap: 12, flexWrap: 'wrap', fontSize: 14, color: textColor }}>
         {canAuth ? (
           <>
-            <span style={{ color: signedInColor, fontWeight: 'bold' }}>✅ YouTube signed in</span>
+            <span style={{ color: signedInColor, fontWeight: 'bold' }}>✅ YouTube signed in (verified)</span>
             <button
               onClick={clearAuth}
               disabled={clearAuthLoading}
@@ -203,6 +332,38 @@ function YouTubeAuth({ compact = false, returnUrl = '/youtube', onAuthStateChang
               {clearAuthLoading ? 'Clearing...' : 'Clear YouTube Auth'}
             </button>
           </>
+        ) : isChecking ? (
+          <>
+            <span style={{ color: textColor }}>⏳ Verifying YouTube sign-in…</span>
+          </>
+        ) : showInvalidBanner ? (
+          <div style={{
+            width: '100%',
+            display: 'flex', flexDirection: 'column', gap: 8,
+            padding: '10px 12px',
+            background: darkMode ? 'rgba(220,53,69,0.15)' : '#fff5f5',
+            border: `1px solid ${darkMode ? '#b14b56' : '#feb2b2'}`,
+            borderRadius: 6, color: textColor,
+          }}>
+            <div style={{ fontWeight: 700, color: darkMode ? '#fc8181' : '#c53030' }}>
+              ⚠️ YouTube sign-in is invalid — uploads will fail
+            </div>
+            <div style={{ fontSize: 13 }}>
+              {reasonLabel || 'Your stored YouTube credentials are no longer valid.'} Please sign in again to continue.
+            </div>
+            <div style={{ display: 'flex', gap: 8, flexWrap: 'wrap' }}>
+              <button
+                onClick={handleSignIn}
+                disabled={authUrlLoading || !authUrl}
+                style={{
+                  padding: '6px 14px', fontSize: 13, background: authUrlLoading ? '#6c757d' : '#007bff',
+                  color: 'white', border: 'none', borderRadius: 4, cursor: authUrlLoading ? 'not-allowed' : 'pointer', fontWeight: 'bold',
+                }}
+              >
+                {authUrlLoading ? 'Loading…' : 'Sign in to YouTube again'}
+              </button>
+            </div>
+          </div>
         ) : (
           <>
             <span style={{ color: notSignedInColor }}>Not signed in to YouTube</span>

--- a/app/(main)/layout.js
+++ b/app/(main)/layout.js
@@ -625,7 +625,7 @@ export default function RootLayout({ children }) {
             </div>
           </nav>
           <main
-            className={`${styles.content} ${sidebarActive && isMobile ? styles.pushed : ''} ${darkMode && pathname !== '/vinyl-digitizer' ? `${styles.darkContent} darkContent` : ''}`}
+            className={`${styles.content} ${sidebarActive && isMobile ? styles.pushed : ''} ${darkMode ? `${styles.darkContent} darkContent` : ''}`}
             style={{ background: darkMode ? colors.DarkMuted : colors.LightMuted }}
           >
             <div className={styles.contentWrapper}>

--- a/app/(main)/layout.module.css
+++ b/app/(main)/layout.module.css
@@ -410,6 +410,10 @@
   .content {
     width: 100%;
     transition: none;
+    padding: 8px;
+  }
+  .contentBody {
+    padding: 4px 0;
   }
   
   /* Smaller text for mobile to prevent cutoff */

--- a/app/(main)/vinyl-digitizer/page.js
+++ b/app/(main)/vinyl-digitizer/page.js
@@ -9,6 +9,7 @@ import { ColorContext } from "../ColorContext";
 import {
   extractTagsFromDiscogs,
   buildTagString,
+  sanitizeYouTubeTag,
   generateVideoTitleRecommendations,
   buildTimestampDescription,
   formatTimestamp,
@@ -70,6 +71,15 @@ function formatTime(s) {
   const sec = Math.floor(s % 60);
   const ms = Math.floor((s % 1) * 100);
   return `${m}:${sec.toString().padStart(2, "0")}.${ms.toString().padStart(2, "0")}`;
+}
+
+// Format seconds as HH:MM:SS (always shows hours, even if 0)
+function formatHMS(s) {
+  if (s == null || !isFinite(s) || s < 0) return "—";
+  const h = Math.floor(s / 3600);
+  const m = Math.floor((s % 3600) / 60);
+  const sec = Math.floor(s % 60);
+  return `${h.toString().padStart(2, "0")}:${m.toString().padStart(2, "0")}:${sec.toString().padStart(2, "0")}`;
 }
 
 function formatBytes(b) {
@@ -150,6 +160,17 @@ export default function VinylDigitizerPage() {
   // Audio source
   const [audioMode, setAudioMode] = useState("upload");
   const [audioFile, setAudioFile] = useState(null);
+  // Every audio file the user has dropped/uploaded/recorded this session
+  const [allAudioFiles, setAllAudioFiles] = useState([]);
+  // Per-file duration cache keyed by "name:size", populated asynchronously
+  const [audioDurations, setAudioDurations] = useState({}); // { "name:size": seconds }
+  // When >1 files were uploaded in a single drop, prompt user on Step 2 to pick which to edit
+  const [pendingAudioFiles, setPendingAudioFiles] = useState([]);
+  // Whether the user has acknowledged the audio-file picker on the current visit.
+  // Reset whenever the user navigates back to Step 1 so the picker re-shows.
+  const [audioPickConfirmed, setAudioPickConfirmed] = useState(false);
+  // File keys whose filename cell the user has clicked to expand (no truncation)
+  const [expandedFilenames, setExpandedFilenames] = useState(new Set());
   const [isRecording, setIsRecording] = useState(false);
   const [recordingTime, setRecordingTime] = useState(0);
   const [recordingLevel, setRecordingLevel] = useState(0);
@@ -163,6 +184,13 @@ export default function VinylDigitizerPage() {
   const [currentTime, setCurrentTime] = useState(0);
   const [volume, setVolume] = useState(1);
   const [tracks, setTracks] = useState([]); // [{id, startTime, endTime, name}]
+
+  // Visible time range of the zoomview (for positioning boundary handles)
+  const [viewRange, setViewRange] = useState({ start: 0, end: 0 });
+  const [zoomviewWidth, setZoomviewWidth] = useState(0);
+  // Tracks currently being dragged (live override for handle rendering during drag)
+  const dragStateRef = useRef(null);
+  const [, forceHandleRender] = useState(0);
 
   // Album info
   const [discogsUrl, setDiscogsUrl] = useState("");
@@ -249,7 +277,12 @@ export default function VinylDigitizerPage() {
   const [ytUploadProgress, setYtUploadProgress] = useState(null);
   const [ytUploadResult, setYtUploadResult] = useState(null);
   const [ytUploadError, setYtUploadError] = useState("");
+  const [ytUploadAuthError, setYtUploadAuthError] = useState(null); // { reason, raw } when invalid_grant / 401
   const [ytAuthState, setYtAuthState] = useState({ canAuth: false });
+  // Clear the upload auth-error banner once the user successfully re-authenticates
+  useEffect(() => {
+    if (ytAuthState.canAuth && ytUploadAuthError) setYtUploadAuthError(null);
+  }, [ytAuthState.canAuth]); // eslint-disable-line react-hooks/exhaustive-deps
   const [thumbnailFile, setThumbnailFile] = useState(null);
   const [thumbnailPreview, setThumbnailPreview] = useState(null);
   const [embedArtFile, setEmbedArtFile] = useState(null); // album art to embed in FLAC exports
@@ -314,7 +347,7 @@ export default function VinylDigitizerPage() {
     videoImages.forEach(img => { if (img.thumbUrl) URL.revokeObjectURL(img.thumbUrl); if (img.previewUrl) URL.revokeObjectURL(img.previewUrl); });
     if (renderedVideoSrc) URL.revokeObjectURL(renderedVideoSrc);
     if (thumbnailPreview) URL.revokeObjectURL(thumbnailPreview);
-    setAudioFile(null); setChannelData(null); setDuration(0); setTracks([]); setCurrentTime(0); setIsPlaying(false);
+    setAudioFile(null); setAllAudioFiles([]); setAudioDurations({}); setExpandedFilenames(new Set()); setPendingAudioFiles([]); setAudioPickConfirmed(false); setChannelData(null); setDuration(0); setTracks([]); setCurrentTime(0); setIsPlaying(false);
     setDiscogsUrl(""); setDiscogsData(null); setDiscogsError(""); setTrackNames([]); setManualTrackCount(""); setProjectName("My Album");
     setExportedTracks([]); setSelectedTracks(new Set()); setMessage("");
     setVideoImages([]); setSelectedVideoImages(new Set()); setSelectedVideoAudios(new Set()); setRenderedVideoSrc(null);
@@ -331,7 +364,7 @@ export default function VinylDigitizerPage() {
   const resetStep = (stepNum) => {
     if (stepNum === 1) {
       if (audioUrlRef.current) URL.revokeObjectURL(audioUrlRef.current);
-      setAudioFile(null); setChannelData(null); setDuration(0); setMessage("");
+      setAudioFile(null); setAllAudioFiles([]); setAudioDurations({}); setExpandedFilenames(new Set()); setPendingAudioFiles([]); setAudioPickConfirmed(false); setChannelData(null); setDuration(0); setMessage("");
       if (peaksRef.current) { try { peaksRef.current.destroy(); } catch {} peaksRef.current = null; }
     } else if (stepNum === 2) {
       setDiscogsUrl(""); setDiscogsData(null); setDiscogsError(""); setTrackNames([]); setManualTrackCount("");
@@ -631,6 +664,32 @@ export default function VinylDigitizerPage() {
     decode();
   }, [audioFile]);
 
+  // Read durations for each uploaded audio file (lightweight metadata-only read)
+  useEffect(() => {
+    let cancelled = false;
+    const missing = allAudioFiles.filter(f => !(`${f.name}:${f.size}` in audioDurations));
+    if (missing.length === 0) return;
+    missing.forEach(f => {
+      const key = `${f.name}:${f.size}`;
+      const url = URL.createObjectURL(f);
+      const a = new Audio();
+      const cleanup = () => { URL.revokeObjectURL(url); };
+      a.addEventListener('loadedmetadata', () => {
+        cleanup();
+        if (cancelled) return;
+        setAudioDurations(prev => ({ ...prev, [key]: a.duration }));
+      });
+      a.addEventListener('error', () => {
+        cleanup();
+        if (cancelled) return;
+        setAudioDurations(prev => ({ ...prev, [key]: null }));
+      });
+      a.preload = 'metadata';
+      a.src = url;
+    });
+    return () => { cancelled = true; };
+  }, [allAudioFiles]); // eslint-disable-line react-hooks/exhaustive-deps
+
   // Volume suggestion — compute RMS when audio loads
   useEffect(() => {
     if (!channelData || channelData.length === 0) { setVolumeSuggestion(null); return; }
@@ -735,6 +794,9 @@ export default function VinylDigitizerPage() {
   useEffect(() => { autoSplitDoneRef.current = false; }, [audioFile]);
   useEffect(() => { if (step < 3) autoSplitDoneRef.current = false; }, [step]);
   useEffect(() => { window.scrollTo({ top: 0, behavior: 'smooth' }); }, [step]);
+  // When the user returns to Step 1, force the audio picker to re-prompt
+  // the next time they enter Step 2.
+  useEffect(() => { if (step === 1) setAudioPickConfirmed(false); }, [step]);
   useEffect(() => {
     if (step === 3 && channelData && duration > 0 && !autoSplitDoneRef.current && !isLoadingWaveform) {
       autoSplitDoneRef.current = true;
@@ -812,6 +874,7 @@ export default function VinylDigitizerPage() {
                   const levels = [256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536];
                   retryInstance.zoom.setZoom(levels.length - 1);
                 } catch {}
+                try { retryInstance.views.getView('zoomview')?.enableAutoScroll(false); } catch {}
                 if (currentTracks && currentTracks.length > 0) {
                   currentTracks.forEach((track, i) => {
                     retryInstance.segments.add({
@@ -830,6 +893,13 @@ export default function VinylDigitizerPage() {
                     setExportedTracks([]);
                   }, 50);
                 });
+                retryInstance.on('zoomview.update', ({ startTime, endTime }) => {
+                  setViewRange({ start: startTime, end: endTime });
+                });
+                try {
+                  const v = retryInstance.views.getView('zoomview');
+                  if (v) setViewRange({ start: v.getStartTime(), end: v.getEndTime() });
+                } catch {}
                 resolve();
               });
               return;
@@ -844,6 +914,8 @@ export default function VinylDigitizerPage() {
             const levels = [256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536];
             peaksInstance.zoom.setZoom(levels.length - 1);
           } catch {}
+          // Disable auto-scroll so zoom/playback doesn't yank the view back to the playhead
+          try { peaksInstance.views.getView('zoomview')?.enableAutoScroll(false); } catch {}
 
           // Add existing tracks as segments
           if (currentTracks && currentTracks.length > 0) {
@@ -897,6 +969,14 @@ export default function VinylDigitizerPage() {
               setExportedTracks([]);
             }, 50);
           });
+
+          peaksInstance.on('zoomview.update', ({ startTime, endTime }) => {
+            setViewRange({ start: startTime, end: endTime });
+          });
+          try {
+            const v = peaksInstance.views.getView('zoomview');
+            if (v) setViewRange({ start: v.getStartTime(), end: v.getEndTime() });
+          } catch {}
 
           resolve();
         });
@@ -1068,13 +1148,138 @@ export default function VinylDigitizerPage() {
     else if (e.deltaY > 0) zoomOut();
   }, []);
 
-  // Attach wheel listener to zoomview (needs {passive: false} to preventDefault)
+  // Attach wheel listener to zoomview (needs {passive: false} to preventDefault).
+  // Re-run when entering step 3 since the zoomview div only mounts in that step.
   useEffect(() => {
-    const el = zoomviewRef.current;
-    if (!el) return;
-    el.addEventListener("wheel", handleWaveWheel, { passive: false });
-    return () => el.removeEventListener("wheel", handleWaveWheel);
-  }, [handleWaveWheel]);
+    if (step !== 3) return;
+    let attached = null;
+    let raf = 0;
+    const tryAttach = () => {
+      const el = zoomviewRef.current;
+      if (el && attached !== el) {
+        if (attached) attached.removeEventListener("wheel", handleWaveWheel, { capture: true });
+        el.addEventListener("wheel", handleWaveWheel, { passive: false, capture: true });
+        attached = el;
+        return;
+      }
+      if (!el) raf = requestAnimationFrame(tryAttach);
+    };
+    tryAttach();
+    return () => {
+      if (raf) cancelAnimationFrame(raf);
+      if (attached) attached.removeEventListener("wheel", handleWaveWheel, { capture: true });
+    };
+  }, [step, handleWaveWheel]);
+
+  // Track zoomview pixel width via ResizeObserver (for boundary handle positioning)
+  useEffect(() => {
+    if (step !== 3) return;
+    let observer = null;
+    let raf = 0;
+    const tryObserve = () => {
+      const el = zoomviewRef.current;
+      if (!el) { raf = requestAnimationFrame(tryObserve); return; }
+      setZoomviewWidth(el.clientWidth);
+      observer = new ResizeObserver(entries => {
+        for (const entry of entries) setZoomviewWidth(entry.contentRect.width);
+      });
+      observer.observe(el);
+    };
+    tryObserve();
+    return () => {
+      if (raf) cancelAnimationFrame(raf);
+      if (observer) observer.disconnect();
+    };
+  }, [step]);
+
+  // ---- Boundary handle drag (above-waveform splitters) ----
+  const beginBoundaryDrag = useCallback((e, mode, idxLeft, idxRight) => {
+    // mode: 'joint-move' | 'joint-split' | 'solo-end' | 'solo-start'
+    e.preventDefault();
+    e.stopPropagation();
+    if (!peaksRef.current) return;
+    const view = peaksRef.current.views.getView('zoomview');
+    const containerEl = zoomviewRef.current;
+    if (!view || !containerEl) return;
+    const startMouseX = e.clientX;
+    const containerRect = containerEl.getBoundingClientRect();
+    const widthPx = containerRect.width || 1;
+
+    // Snapshot current track times so we can compute fresh values per move
+    const startEnd = idxLeft != null ? tracks[idxLeft].endTime : null;
+    const startStart = idxRight != null ? tracks[idxRight].startTime : null;
+
+    dragStateRef.current = { mode, idxLeft, idxRight, splitDir: null };
+    forceHandleRender(n => n + 1);
+
+    const pxToSeconds = (px) => {
+      const range = view.getEndTime() - view.getStartTime();
+      return (px / widthPx) * range;
+    };
+
+    const onMove = (ev) => {
+      const dx = ev.clientX - startMouseX;
+      const dt = pxToSeconds(dx);
+      const segL = idxLeft != null ? peaksRef.current.segments.getSegment(tracks[idxLeft].id) : null;
+      const segR = idxRight != null ? peaksRef.current.segments.getSegment(tracks[idxRight].id) : null;
+      // Re-render handle overlay so the handle follows the cursor
+      requestAnimationFrame(() => forceHandleRender(n => n + 1));
+
+      if (mode === 'joint-move') {
+        // Move both boundaries together; clamp so neither crosses the other side.
+        const prevEnd = idxLeft > 0 ? tracks[idxLeft - 1].endTime : 0;
+        const nextStart = idxRight < tracks.length - 1 ? tracks[idxRight + 1].startTime : duration;
+        const minT = Math.max(prevEnd, (tracks[idxLeft].startTime + 0.05));
+        const maxT = Math.min(nextStart, (tracks[idxRight].endTime - 0.05));
+        const t = Math.max(minT, Math.min(maxT, startEnd + dt));
+        if (segL) segL.update({ endTime: t });
+        if (segR) segR.update({ startTime: t });
+      } else if (mode === 'joint-split') {
+        // Direction-based: dragging left moves track[idxLeft].endTime backwards;
+        // dragging right moves track[idxRight].startTime forwards.
+        const st = dragStateRef.current;
+        if (st && st.splitDir == null && Math.abs(dx) > 2) {
+          st.splitDir = dx < 0 ? 'left' : 'right';
+          forceHandleRender(n => n + 1);
+        }
+        const dir = dragStateRef.current?.splitDir;
+        if (dir === 'left' && segL) {
+          const minT = Math.max((idxLeft > 0 ? tracks[idxLeft - 1].endTime : 0), tracks[idxLeft].startTime + 0.05);
+          const t = Math.max(minT, Math.min(startEnd, startEnd + dt));
+          segL.update({ endTime: t });
+        } else if (dir === 'right' && segR) {
+          const maxT = Math.min((idxRight < tracks.length - 1 ? tracks[idxRight + 1].startTime : duration), tracks[idxRight].endTime - 0.05);
+          const t = Math.min(maxT, Math.max(startStart, startStart + dt));
+          segR.update({ startTime: t });
+        }
+      } else if (mode === 'solo-end' && segL) {
+        const minT = Math.max((idxLeft > 0 ? tracks[idxLeft - 1].endTime : 0), tracks[idxLeft].startTime + 0.05);
+        const maxT = (idxLeft < tracks.length - 1) ? tracks[idxLeft + 1].startTime : duration;
+        const t = Math.max(minT, Math.min(maxT, startEnd + dt));
+        segL.update({ endTime: t });
+      } else if (mode === 'solo-start' && segR) {
+        const minT = (idxRight > 0) ? tracks[idxRight - 1].endTime : 0;
+        const maxT = Math.min((idxRight < tracks.length - 1 ? tracks[idxRight + 1].startTime : duration), tracks[idxRight].endTime - 0.05);
+        const t = Math.max(minT, Math.min(maxT, startStart + dt));
+        segR.update({ startTime: t });
+      }
+    };
+
+    const onUp = () => {
+      window.removeEventListener('mousemove', onMove);
+      window.removeEventListener('mouseup', onUp);
+      // Commit final times from peaks segments back to React state
+      const segs = peaksRef.current.segments.getSegments().sort((a, b) => a.startTime - b.startTime);
+      const stripNum = (label) => { const m = (label || '').match(/^\d+\.\s*(.*)$/); return m ? m[1] : (label || 'Track'); };
+      setTracks(segs.map(s => ({ id: s.id, startTime: s.startTime, endTime: s.endTime, name: stripNum(s.labelText) })));
+      setExportedTracks([]);
+      dragStateRef.current = null;
+      forceHandleRender(n => n + 1);
+    };
+
+    window.addEventListener('mousemove', onMove);
+    window.addEventListener('mouseup', onUp);
+  }, [tracks, duration]);
 
   // ---- Track manipulation ----
   const generateTrackId = () => `track-${Date.now()}-${Math.random().toString(36).slice(2, 6)}`;
@@ -1160,7 +1365,9 @@ export default function VinylDigitizerPage() {
       mr.ondataavailable = e => { if (e.data.size > 0) recordedChunksRef.current.push(e.data); };
       mr.onstop = () => {
         const blob = new Blob(recordedChunksRef.current, { type: "audio/webm" });
-        setAudioFile(new File([blob], `recording-${Date.now()}.webm`, { type: "audio/webm" }));
+        const file = new File([blob], `recording-${Date.now()}.webm`, { type: "audio/webm" });
+        setAudioFile(file);
+        setAllAudioFiles(prev => [...prev, file]);
         stream.getTracks().forEach(t => t.stop());
         if (audioCtxRef.current) { audioCtxRef.current.close(); audioCtxRef.current = null; }
         cancelAnimationFrame(animFrameRef.current);
@@ -1183,13 +1390,58 @@ export default function VinylDigitizerPage() {
   // ---- Upload ----
   const handleDrop = e => {
     e.preventDefault();
+    e.stopPropagation();
     const files = Array.from(e.dataTransfer.files);
-    const audioF = files.find(f => f.type.startsWith("audio/"));
+    const audioFiles = files.filter(f => f.type.startsWith("audio/"));
     const imageFiles = files.filter(f => f.type.startsWith("image/"));
-    if (audioF) setAudioFile(audioF);
-    if (imageFiles.length > 0) addImagesToVideo(imageFiles);
+
+    if (audioFiles.length > 0) {
+      setAllAudioFiles(prev => {
+        const existingKeys = new Set(prev.map(f => `${f.name}:${f.size}`));
+        const fresh = audioFiles.filter(f => !existingKeys.has(`${f.name}:${f.size}`));
+        return [...prev, ...fresh];
+      });
+      if (audioFiles.length === 1) {
+        setAudioFile(audioFiles[0]);
+        setPendingAudioFiles([]);
+      } else {
+        // Pre-select the first file so the user can advance to step 2,
+        // but remember all of them so step 2 can show a picker.
+        setPendingAudioFiles(audioFiles);
+        setAudioFile(audioFiles[0]);
+        setMessage(`${audioFiles.length} audio files dropped — confirm which to edit on Step 2.`);
+      }
+    }
+
+    if (imageFiles.length > 0) {
+      addImagesToVideo(imageFiles);
+      // Also set the first dropped image as the embedded album art for FLAC export (step 4)
+      if (!embedArtFile) {
+        const f = imageFiles[0];
+        setEmbedArtFile(f);
+        if (embedArtPreview) URL.revokeObjectURL(embedArtPreview);
+        setEmbedArtPreview(URL.createObjectURL(f));
+        setExportedTracks([]);
+      }
+    }
   };
-  const handleFileInput = e => { if (e.target.files.length > 0) setAudioFile(e.target.files[0]); };
+  const handleFileInput = e => {
+    const files = Array.from(e.target.files || []);
+    if (files.length === 0) return;
+    setAllAudioFiles(prev => {
+      const existingKeys = new Set(prev.map(f => `${f.name}:${f.size}`));
+      const fresh = files.filter(f => !existingKeys.has(`${f.name}:${f.size}`));
+      return [...prev, ...fresh];
+    });
+    if (files.length === 1) {
+      setAudioFile(files[0]);
+      setPendingAudioFiles([]);
+    } else {
+      setPendingAudioFiles(files);
+      setAudioFile(files[0]);
+      setMessage(`${files.length} audio files selected — confirm which to edit on Step 2.`);
+    }
+  };
 
   // ---- Discogs ----
   const fetchDiscogs = async () => {
@@ -1651,6 +1903,8 @@ export default function VinylDigitizerPage() {
       const img = new Image();
       const url = URL.createObjectURL(file);
       img.onload = () => {
+        const naturalWidth = img.width;
+        const naturalHeight = img.height;
         const scale = Math.min(maxSize / img.width, maxSize / img.height, 1);
         const w = Math.round(img.width * scale);
         const h = Math.round(img.height * scale);
@@ -1660,12 +1914,13 @@ export default function VinylDigitizerPage() {
         canvas.getContext('2d').drawImage(img, 0, 0, w, h);
         URL.revokeObjectURL(url);
         canvas.toBlob((blob) => {
-          resolve(blob ? URL.createObjectURL(blob) : URL.createObjectURL(file));
+          const thumbUrl = blob ? URL.createObjectURL(blob) : URL.createObjectURL(file);
+          resolve({ thumbUrl, width: naturalWidth, height: naturalHeight });
         }, 'image/jpeg', 0.7);
       };
       img.onerror = () => {
         URL.revokeObjectURL(url);
-        resolve(URL.createObjectURL(file));
+        resolve({ thumbUrl: URL.createObjectURL(file), width: 0, height: 0 });
       };
       img.src = url;
     });
@@ -1674,15 +1929,31 @@ export default function VinylDigitizerPage() {
   const addImagesToVideo = async (files) => {
     const imageFiles = Array.from(files || []).filter(f => f?.type?.startsWith("image/"));
     if (!imageFiles.length) return;
-    setImageLoadingStatus({ loaded: 0, total: imageFiles.length, current: imageFiles[0].name });
-    for (let i = 0; i < imageFiles.length; i++) {
-      const f = imageFiles[i];
-      setImageLoadingStatus({ loaded: i, total: imageFiles.length, current: f.name });
+    // Dedupe against current state AND within the incoming batch (in case the
+    // same file appears twice in one drop). stopPropagation in handleDrop
+    // already prevents the handler from firing twice for the same event, so
+    // this check is sufficient.
+    const existingKeys = new Set(videoImages.map(img => `${img.file.name}:${img.file.size}`));
+    const seenInBatch = new Set();
+    const fresh = [];
+    for (const f of imageFiles) {
+      const key = `${f.name}:${f.size}`;
+      if (existingKeys.has(key) || seenInBatch.has(key)) continue;
+      seenInBatch.add(key);
+      fresh.push(f);
+    }
+    if (!fresh.length) return;
+    setImageLoadingStatus({ loaded: 0, total: fresh.length, current: fresh[0].name });
+    for (let i = 0; i < fresh.length; i++) {
+      const f = fresh[i];
+      setImageLoadingStatus({ loaded: i, total: fresh.length, current: f.name });
       const id = `${f.name}-${Date.now()}-${Math.random().toString(36).slice(2,6)}`;
-      const thumbUrl = await createThumbnail(f);
-      const previewUrl = URL.createObjectURL(f);
-      setVideoImages(prev => [...prev, { id, file: f, thumbUrl, previewUrl, stretchToFit: false, useBlurBg: false, paddingColor: "#000000" }]);
+      // Add a placeholder entry immediately so the row appears with a spinner
+      setVideoImages(prev => [...prev, { id, file: f, thumbUrl: null, previewUrl: null, loading: true, width: 0, height: 0, stretchToFit: false, useBlurBg: false, paddingColor: "#000000" }]);
       setSelectedVideoImages(prev => { const next = new Set(prev); next.add(id); return next; });
+      const { thumbUrl, width, height } = await createThumbnail(f);
+      const previewUrl = URL.createObjectURL(f);
+      setVideoImages(prev => prev.map(img => img.id === id ? { ...img, thumbUrl, previewUrl, width, height, loading: false } : img));
     }
     setImageLoadingStatus(null);
   };
@@ -2087,7 +2358,7 @@ export default function VinylDigitizerPage() {
   const uploadToYouTube = async (videoUrlOverride) => {
     const videoUrl = videoUrlOverride || renderedVideoSrc;
     if (!videoUrl || ytUploading) return;
-    setYtUploading(true); setYtUploadProgress(0); setYtUploadError(""); setYtUploadResult(null);
+    setYtUploading(true); setYtUploadProgress(0); setYtUploadError(""); setYtUploadAuthError(null); setYtUploadResult(null);
     try {
       const tokens = await getTokensRef.current?.getTokens();
       if (!tokens) { setYtUploadError("Not signed in to YouTube."); setYtUploading(false); return; }
@@ -2099,7 +2370,19 @@ export default function VinylDigitizerPage() {
       fd.append("title", currentYtData.title || name);
       fd.append("description", currentYtData.description || "");
       fd.append("privacyStatus", currentYtData.privacyStatus || "private");
-      fd.append("tags", currentYtData.tags || "");
+      const cleanedTags = (currentYtData.tags || "")
+        .split(",")
+        .map(t => sanitizeYouTubeTag(t))
+        .filter(Boolean);
+      let tagsTotal = 0;
+      const safeTags = [];
+      for (const t of cleanedTags) {
+        const projected = tagsTotal + (safeTags.length ? 2 : 0) + t.length;
+        if (projected > YT_LIMITS.tags) break;
+        safeTags.push(t);
+        tagsTotal = projected;
+      }
+      fd.append("tags", safeTags.join(", "));
       fd.append("tokens", JSON.stringify(tokens));
       if (thumbnailFile) fd.append("thumbnail", thumbnailFile, thumbnailFile.name);
       const fileSizeMB = (videoBlob.size / (1024 * 1024)).toFixed(1);
@@ -2120,12 +2403,30 @@ export default function VinylDigitizerPage() {
             if (xhr.status >= 200 && xhr.status < 300) setYtUploadResult(data);
             else {
               console.error("YouTube upload error — full server response:", data);
-              let errMsg = data.error || `Upload failed (${xhr.status})`;
-              if (xhr.status === 413) errMsg = `File too large (${fileSizeMB} MB). Maximum upload size is ${maxSizeMB} MB. Try a lower resolution.`;
-              else if (/invalid.*title|empty.*title/i.test(errMsg)) errMsg += " — Try shortening the title (max 100 characters).";
-              else if (/description/i.test(errMsg)) errMsg += " — Try shortening the description (max 5,000 characters).";
-              else if (/tag/i.test(errMsg)) errMsg += " — Try reducing tags (max 500 characters total, each tag max 30 chars).";
-              setYtUploadError(errMsg);
+              const rawErr = String(data.error || data.error_description || "");
+              const looksLikeAuth =
+                /invalid_grant|invalid_token|unauthorized_client|token has been expired|not signed in/i.test(rawErr) ||
+                xhr.status === 401 || xhr.status === 403;
+              if (looksLikeAuth) {
+                // Clear the stale tokens client-side so YouTubeAuth re-renders as signed-out
+                try {
+                  localStorage.removeItem('youtube_tokens');
+                  localStorage.removeItem('youtube_auth_code');
+                  localStorage.removeItem('youtube_auth_scope');
+                  localStorage.removeItem('youtube_auth_set_time');
+                } catch {}
+                // Tell YouTubeAuth to re-verify (will flip canAuth to false)
+                try { getTokensRef.current?.verifyTokens?.(); } catch {}
+                setYtUploadAuthError({ reason: rawErr || `HTTP ${xhr.status}`, raw: data });
+                setYtUploadError("");
+              } else {
+                let errMsg = rawErr || `Upload failed (${xhr.status})`;
+                if (xhr.status === 413) errMsg = `File too large (${fileSizeMB} MB). Maximum upload size is ${maxSizeMB} MB. Try a lower resolution.`;
+                else if (/invalid.*title|empty.*title/i.test(errMsg)) errMsg += " — Try shortening the title (max 100 characters).";
+                else if (/description/i.test(errMsg)) errMsg += " — Try shortening the description (max 5,000 characters).";
+                else if (/tag/i.test(errMsg)) errMsg += " — Try reducing tags (max 500 characters total, each tag max 30 chars).";
+                setYtUploadError(errMsg);
+              }
             }
           } catch (parseErr) { console.error("YouTube upload error — failed to parse response. Status:", xhr.status, "Raw response:", xhr.responseText, parseErr); setYtUploadError(`Failed to parse server response (HTTP ${xhr.status})`); }
           resolve();
@@ -2173,9 +2474,9 @@ export default function VinylDigitizerPage() {
   const lastYtDiscogsUrlRef = useRef(null);
   const lastYtVideoSrcRef = useRef(null);
 
-  // Pre-fill YouTube metadata when entering Step 6 or when discogs data / rendered video changes
+  // Pre-fill YouTube metadata when entering Step 5 or when discogs data / rendered video changes
   useEffect(() => {
-    if (step !== 6) return;
+    if (step !== 5) return;
     const discogsChanged = discogsData && discogsUrl && lastYtDiscogsUrlRef.current !== discogsUrl;
     const videoChanged = renderedVideoSrc && lastYtVideoSrcRef.current !== renderedVideoSrc;
     const needsTitle = !ytUploadData.title || discogsChanged;
@@ -2233,13 +2534,7 @@ export default function VinylDigitizerPage() {
           <p className={styles.subtitle}>Record or upload vinyl audio → detect tracks → export with Discogs metadata</p>
         </div>
         <div className={styles.headerRight}>
-          <div className={styles.projectNameWrap}>
-            <label className={styles.projectNameLabel}>Project Title</label>
-            <input className={styles.projectNameInput} value={projectName} onChange={e => setProjectName(e.target.value)} placeholder="Project name…" />
-          </div>
-          <button className={styles.historyBtn} onClick={() => setShowHistory(v => !v)}>
-            📚 History {projects.length > 0 && <span className={styles.historyBadge}>{projects.length}</span>}
-          </button>
+          <button className={styles.skipBtn} onClick={resetAll}>Start Over</button>
         </div>
       </div>
 
@@ -2312,7 +2607,7 @@ export default function VinylDigitizerPage() {
       {/* Steps — sticky when rendering/uploading */}
       <div className={`${styles.stepBarWrap} ${(isRenderingVideo || ytUploading) ? styles.stepBarSticky : ""}`}>
         <div className={styles.stepBar}>
-          {["Audio Source", "Album Info", "Waveform & Markers", "Audio Export", "Video Render", "YouTube Upload"].map((label, i) => (
+          {["Input", "Tracks", "Waveform", "Audio", "Video"].map((label, i) => (
             <div key={i} className={`${styles.stepItem} ${step === i + 1 ? styles.stepActive : ""} ${step > i + 1 ? styles.stepDone : ""}`}
               onClick={() => setStep(i + 1)}
               style={{ cursor: "pointer" }}
@@ -2322,7 +2617,7 @@ export default function VinylDigitizerPage() {
               {i === 4 && isRenderingVideo && (
                 <span className={styles.stepProgress}>{videoRenderProgress !== null ? ` ${(videoRenderProgress * 100).toFixed(0)}%` : " …"}</span>
               )}
-              {i < 5 && <div className={styles.stepLine} />}
+              {i < 4 && <div className={styles.stepLine} />}
             </div>
           ))}
         </div>
@@ -2331,7 +2626,12 @@ export default function VinylDigitizerPage() {
             ⚠️ WARNING: {isRenderingVideo ? `Video is rendering${videoRenderProgress !== null ? ` (${(videoRenderProgress * 100).toFixed(0)}%)` : ""}` : `Video is uploading${ytUploadProgress !== null ? ` (${ytUploadProgress}%)` : ""}`} — do not navigate away from this page!
           </div>
         )}
-        {ytUploadError && !ytUploading && (
+        {ytUploadAuthError && !ytUploading && (
+          <div className={styles.renderingWarningBanner} style={{animation:"none", background: "#fed7d7", color: "#742a2a"}}>
+            ⚠️ YouTube sign-in expired — see the YouTube Upload Details panel below to sign in again.
+          </div>
+        )}
+        {ytUploadError && !ytUploadAuthError && !ytUploading && (
           <div className={styles.renderingWarningBanner} style={{animation:"none"}}>
             Upload Error: {ytUploadError}
           </div>
@@ -2344,7 +2644,7 @@ export default function VinylDigitizerPage() {
           {/* ---- STEP 1 ---- */}
           {step === 1 && (
             <div className={styles.card}>
-              <h2 className={styles.cardTitle}>Step 1: Audio Source</h2>
+              <h2 className={styles.cardTitle}>Step 1: Input</h2>
               <div className={styles.tabRow}>
                 <button className={`${styles.tab} ${audioMode === "upload" ? styles.tabActive : ""}`} onClick={() => setAudioMode("upload")}>Upload File</button>
                 <button className={`${styles.tab} ${audioMode === "record" ? styles.tabActive : ""}`} onClick={() => setAudioMode("record")}>Record Live</button>
@@ -2354,9 +2654,9 @@ export default function VinylDigitizerPage() {
                 <div>
                   <div className={styles.dropZone} onDrop={handleDrop} onDragOver={e => e.preventDefault()}>
                     <div className={styles.dropIcon}>🎵</div>
-                    <p className={styles.dropText}>Drop audio file here or click to browse</p>
-                    <p className={styles.dropHint}>WAV · FLAC · MP3 · AIFF · OGG · WebM</p>
-                    <input type="file" accept="audio/*" onChange={handleFileInput} className={styles.fileInput} />
+                    <p className={styles.dropText}>Drop audio or image files here, or click to browse audio</p>
+                    <p className={styles.dropHint}>Audio: WAV · FLAC · MP3 · AIFF · OGG · WebM · Images: PNG · JPG (auto-added to album art &amp; video)</p>
+                    <input type="file" accept="audio/*" multiple onChange={handleFileInput} className={styles.fileInput} />
                   </div>
                 </div>
               ) : (
@@ -2377,12 +2677,154 @@ export default function VinylDigitizerPage() {
                 </div>
               )}
 
-              {audioFile && !isRecording && (
-                <div className={styles.fileInfo}>
-                  <span>✅ {audioFile.name}</span>
-                  <span>{formatBytes(audioFile.size)}</span>
-                  {duration > 0 && <span>⏱ {formatTime(duration)}</span>}
-                  {channelData && <span className={styles.fileInfoReady}>Ready</span>}
+              {(() => {
+                const hasFiles = allAudioFiles.length > 0 || videoImages.length > 0;
+                const anyImageLoading = videoImages.some(img => img.loading);
+                const audioReady = !audioFile || !!channelData;
+                const allLoaded = hasFiles && !anyImageLoading && audioReady;
+                if (!allLoaded) return null;
+                return (
+                  <div className={`${styles.fileInfo} ${styles.fileInfoAllReady}`}>
+                    <span>✅ All files loaded</span>
+                  </div>
+                );
+              })()}
+              {allAudioFiles.length > 0 && (
+                <div className={styles.uploadedFilesSection}>
+                  <h3 className={styles.sectionTitle}>Audio Files ({allAudioFiles.length})</h3>
+                  <div className={styles.tableWrap}>
+                    <table className={styles.table}>
+                      <thead>
+                        <tr>
+                          <th>#</th>
+                          <th>Filename</th>
+                          <th>Size</th>
+                          <th>Length</th>
+                          <th>Status</th>
+                          <th></th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {allAudioFiles.map((f, i) => {
+                          const isDecoding = audioFile === f && !channelData;
+                          const key = `${f.name}:${f.size}`;
+                          const dur = audioDurations[key];
+                          const isExpanded = expandedFilenames.has(key);
+                          return (
+                            <tr key={`${f.name}-${f.size}-${i}`}>
+                              <td>{i + 1}</td>
+                              <td
+                                className={`${styles.filenameCell} ${isExpanded ? styles.filenameCellExpanded : ""}`}
+                                title={f.name}
+                                onClick={() => setExpandedFilenames(prev => { const next = new Set(prev); next.has(key) ? next.delete(key) : next.add(key); return next; })}
+                              >{f.name}</td>
+                              <td>{formatBytes(f.size)}</td>
+                              <td className={styles.timeCell}>
+                                {dur == null ? <span className={styles.fileStatusIdle}>—</span> : formatHMS(dur)}
+                              </td>
+                              <td>
+                                {isDecoding ? (
+                                  <span className={styles.fileStatusLoading}>
+                                    <span className={styles.fileLoadingSpinner} />
+                                    <span>Loading…</span>
+                                  </span>
+                                ) : (
+                                  <span className={styles.fileStatusReady}>✓ Ready</span>
+                                )}
+                              </td>
+                              <td>
+                                <button
+                                  className={styles.removeBtn}
+                                  title="Remove this file"
+                                  onClick={() => {
+                                    setAllAudioFiles(prev => prev.filter(x => x !== f));
+                                    setPendingAudioFiles(prev => prev.filter(x => x !== f));
+                                    if (audioFile === f) {
+                                      const next = allAudioFiles.find(x => x !== f) || null;
+                                      setAudioFile(next);
+                                      if (!next) { setChannelData(null); setDuration(0); }
+                                    }
+                                  }}
+                                >×</button>
+                              </td>
+                            </tr>
+                          );
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
+                </div>
+              )}
+
+              {videoImages.length > 0 && (
+                <div className={styles.uploadedFilesSection}>
+                  <h3 className={styles.sectionTitle}>Image Files ({videoImages.length})</h3>
+                  <div className={styles.tableWrap}>
+                    <table className={styles.table}>
+                      <thead>
+                        <tr>
+                          <th></th>
+                          <th>Filename</th>
+                          <th>Size</th>
+                          <th>Resolution</th>
+                          <th>Status</th>
+                          <th></th>
+                        </tr>
+                      </thead>
+                      <tbody>
+                        {videoImages.map((img) => {
+                          const key = `${img.file.name}:${img.file.size}`;
+                          const isExpanded = expandedFilenames.has(key);
+                          return (
+                          <tr key={img.id}>
+                            <td>
+                              {img.loading || !img.thumbUrl ? (
+                                <div className={styles.uploadedThumbPlaceholder}>
+                                  <span className={styles.fileLoadingSpinner} />
+                                </div>
+                              ) : (
+                                <img src={img.thumbUrl} alt="" className={styles.uploadedThumb} />
+                              )}
+                            </td>
+                            <td
+                              className={`${styles.filenameCell} ${isExpanded ? styles.filenameCellExpanded : ""}`}
+                              title={img.file.name}
+                              onClick={() => setExpandedFilenames(prev => { const next = new Set(prev); next.has(key) ? next.delete(key) : next.add(key); return next; })}
+                            >{img.file.name}</td>
+                            <td>{formatBytes(img.file.size)}</td>
+                            <td className={styles.timeCell}>
+                              {img.width && img.height ? `${img.width} × ${img.height}` : <span className={styles.fileStatusIdle}>—</span>}
+                            </td>
+                            <td>
+                              {img.loading ? (
+                                <span className={styles.fileStatusLoading}>
+                                  <span className={styles.fileLoadingSpinner} />
+                                  <span>Loading…</span>
+                                </span>
+                              ) : (
+                                <span className={styles.fileStatusReady}>✓ Ready</span>
+                              )}
+                            </td>
+                            <td>
+                              <button
+                                className={styles.removeBtn}
+                                title="Remove this image"
+                                onClick={() => {
+                                  removeVideoImage(img.id);
+                                  if (embedArtFile === img.file) {
+                                    if (embedArtPreview) URL.revokeObjectURL(embedArtPreview);
+                                    setEmbedArtFile(null);
+                                    setEmbedArtPreview(null);
+                                  }
+                                }}
+                              >×</button>
+                            </td>
+                          </tr>
+                          );
+                        })}
+                      </tbody>
+                    </table>
+                  </div>
                 </div>
               )}
               {message && <p className={styles.msg}>{message}</p>}
@@ -2396,8 +2838,7 @@ export default function VinylDigitizerPage() {
               </div>
 
               <div className={styles.stepNav}>
-                <button className={styles.nextBtn} disabled={!canGoStep2} onClick={() => setStep(2)}>Next: Album Info →</button>
-                <button className={styles.skipBtn} onClick={resetAll}>Start Over</button>
+                <button className={styles.nextBtn} disabled={!canGoStep2} onClick={() => setStep(2)}>Next: Tracks →</button>
               </div>
             </div>
           )}
@@ -2405,7 +2846,56 @@ export default function VinylDigitizerPage() {
           {/* ---- STEP 2 ---- */}
           {step === 2 && (
             <div className={styles.card}>
-              <h2 className={styles.cardTitle}>Step 2: Album Info</h2>
+              <h2 className={styles.cardTitle}>Step 2: Tracks</h2>
+
+              {allAudioFiles.length > 1 && !audioPickConfirmed && (
+                <div className={styles.audioPickerCard}>
+                  <div className={styles.audioPickerHeader}>
+                    📂 You uploaded {allAudioFiles.length} audio files — which one do you want to edit?
+                  </div>
+                  <div className={styles.audioPickerList}>
+                    {allAudioFiles.map((f, i) => (
+                      <button
+                        key={`${f.name}-${f.size}-${i}`}
+                        type="button"
+                        className={`${styles.audioPickerItem} ${audioFile === f ? styles.audioPickerItemActive : ""}`}
+                        onClick={() => {
+                          setAudioFile(f);
+                          setMessage("");
+                        }}
+                      >
+                        <span className={styles.audioPickerName}>{f.name}</span>
+                        <span className={styles.audioPickerSize}>{formatBytes(f.size)}</span>
+                        {audioFile === f && <span className={styles.audioPickerBadge}>Selected</span>}
+                      </button>
+                    ))}
+                  </div>
+                  <div className={styles.audioPickerActions}>
+                    <button
+                      type="button"
+                      className={styles.selectBtn}
+                      disabled={!audioFile}
+                      onClick={() => { setPendingAudioFiles([]); setAudioPickConfirmed(true); }}
+                    >
+                      Confirm selection
+                    </button>
+                    <button
+                      type="button"
+                      className={styles.skipBtn}
+                      onClick={() => { setPendingAudioFiles([]); setAudioPickConfirmed(true); }}
+                    >
+                      Skip editing
+                    </button>
+                    <button
+                      type="button"
+                      className={styles.skipBtn}
+                      onClick={() => { setAudioFile(null); setPendingAudioFiles([]); setStep(1); }}
+                    >
+                      Drop different files
+                    </button>
+                  </div>
+                </div>
+              )}
               <div className={styles.discogsRow}>
                 <div className={styles.discogsModeRow}>
                   <button className={`${styles.tab} ${discogsInputMode === "url" ? styles.tabActive : ""}`} onClick={() => setDiscogsInputMode("url")}>By URL</button>
@@ -2535,21 +3025,54 @@ export default function VinylDigitizerPage() {
 
               <div className={styles.stepNav}>
                 <button className={styles.backBtn} onClick={() => setStep(1)}>← Back</button>
-                <button className={styles.nextBtn} disabled={!canGoStep3} onClick={() => setStep(3)}>Next: Waveform Editor →</button>
-                <button className={styles.skipBtn} onClick={resetAll}>Start Over</button>
+                <button className={styles.nextBtn} disabled={!canGoStep3} onClick={() => setStep(3)}>Next: Waveform →</button>
               </div>
             </div>
           )}
 
           {/* ---- STEP 3 ---- (always mounted to preserve waveform) */}
           <div className={styles.card} style={{ display: step === 3 ? undefined : "none" }}>
-              <h2 className={styles.cardTitle}>Step 3: Waveform &amp; Markers</h2>
+              <h2 className={styles.cardTitle}>Step 3: Waveform</h2>
+
+              {allAudioFiles.length > 1 && (
+                <div className={styles.audioSwitcher}>
+                  <span className={styles.audioSwitcherLabel}>Editing:</span>
+                  <div className={styles.audioSwitcherList}>
+                    {allAudioFiles.map((f, i) => (
+                      <button
+                        key={`${f.name}-${f.size}-${i}`}
+                        type="button"
+                        className={`${styles.audioSwitcherItem} ${audioFile === f ? styles.audioSwitcherItemActive : ""}`}
+                        title={f.name}
+                        onClick={() => {
+                          if (audioFile === f) return;
+                          if (tracks.length > 0 && !window.confirm(`Switch to "${f.name}"? Your current track markers will be cleared.`)) return;
+                          setAudioFile(f);
+                        }}
+                      >
+                        <span className={styles.audioSwitcherName}>{f.name}</span>
+                        {audioFile === f && <span className={styles.audioSwitcherBadge}>✓</span>}
+                      </button>
+                    ))}
+                  </div>
+                </div>
+              )}
 
               {/* Toolbar */}
               <div className={styles.waveToolbar}>
                 <div className={styles.tbGroup}>
                   <button className={styles.playBtnSmall} onClick={togglePlay} disabled={!duration}>{isPlaying ? "⏸" : "▶"}</button>
-                  <span className={styles.timeLabel}>{formatTime(currentTime)} / {formatTime(duration)}</span>
+                  {(() => {
+                    const durStr = formatTime(duration);
+                    const slotWidth = `${Math.max(durStr.length, 7)}ch`;
+                    return (
+                      <span className={styles.timeLabel}>
+                        <span className={styles.timeCurrent} style={{ minWidth: slotWidth }}>{formatTime(currentTime)}</span>
+                        <span className={styles.timeSep}>/</span>
+                        <span className={styles.timeDuration}>{durStr}</span>
+                      </span>
+                    );
+                  })()}
                 </div>
                 <div className={styles.tbSep} />
                 <div className={styles.tbGroup}>
@@ -2581,7 +3104,81 @@ export default function VinylDigitizerPage() {
                 {isLoadingWaveform && (
                   <div className={styles.waveLoading}><div className={styles.spinner} /><span>{waveformLoadStatus || "Loading waveform…"}</span></div>
                 )}
-                <div ref={zoomviewRef} className={styles.zoomview} />
+                <div className={styles.zoomviewWrap}>
+                  <div ref={zoomviewRef} className={styles.zoomview} />
+                  {/* Boundary handles overlay (above the waveform) */}
+                  {(() => {
+                    const range = viewRange.end - viewRange.start;
+                    if (!range || !zoomviewWidth || tracks.length === 0) return null;
+                    const timeToX = (t) => ((t - viewRange.start) / range) * zoomviewWidth;
+                    // Read live segment times from peaks during a drag, falling back to React state
+                    const liveTime = (trackId, field) => {
+                      const seg = peaksRef.current?.segments?.getSegment?.(trackId);
+                      if (seg) return field === 'endTime' ? seg.endTime : seg.startTime;
+                      const t = tracks.find(x => x.id === trackId);
+                      return t ? t[field] : 0;
+                    };
+                    const EPS = 0.02;
+                    const handles = [];
+                    for (let i = 0; i < tracks.length - 1; i++) {
+                      const a = tracks[i];
+                      const b = tracks[i + 1];
+                      const aEnd = liveTime(a.id, 'endTime');
+                      const bStart = liveTime(b.id, 'startTime');
+                      const shared = Math.abs(aEnd - bStart) < EPS;
+                      if (shared) {
+                        const x = timeToX(aEnd);
+                        if (x < -20 || x > zoomviewWidth + 20) continue;
+                        const ds = dragStateRef.current;
+                        const isDragging = ds && ds.idxLeft === i && ds.idxRight === i + 1;
+                        const splitDir = isDragging && ds.mode === 'joint-split' ? ds.splitDir : null;
+                        handles.push(
+                          <div key={`joint-${a.id}-${b.id}`} className={styles.boundaryHandle} style={{ left: x }}>
+                            <div
+                              className={styles.boundaryBar}
+                              title="Drag to move both boundaries together"
+                              onMouseDown={(ev) => beginBoundaryDrag(ev, 'joint-move', i, i + 1)}
+                            />
+                            <div
+                              className={`${styles.boundaryLeg} ${splitDir === 'left' ? styles.boundaryLegLeft : ''} ${splitDir === 'right' ? styles.boundaryLegRight : ''}`}
+                              title="Drag left/right to split into separate start/end"
+                              onMouseDown={(ev) => beginBoundaryDrag(ev, 'joint-split', i, i + 1)}
+                            />
+                          </div>
+                        );
+                      } else {
+                        // Two separate handles
+                        const xL = timeToX(aEnd);
+                        const xR = timeToX(bStart);
+                        if (xL >= -20 && xL <= zoomviewWidth + 20) {
+                          handles.push(
+                            <div key={`solo-end-${a.id}`} className={`${styles.boundaryHandle} ${styles.boundarySolo}`} style={{ left: xL }}>
+                              <div
+                                className={styles.boundaryBar}
+                                title={`Drag to move "${a.name}" end`}
+                                onMouseDown={(ev) => beginBoundaryDrag(ev, 'solo-end', i, null)}
+                              />
+                              <div className={styles.boundaryLeg} onMouseDown={(ev) => beginBoundaryDrag(ev, 'solo-end', i, null)} />
+                            </div>
+                          );
+                        }
+                        if (xR >= -20 && xR <= zoomviewWidth + 20) {
+                          handles.push(
+                            <div key={`solo-start-${b.id}`} className={`${styles.boundaryHandle} ${styles.boundarySolo}`} style={{ left: xR }}>
+                              <div
+                                className={styles.boundaryBar}
+                                title={`Drag to move "${b.name}" start`}
+                                onMouseDown={(ev) => beginBoundaryDrag(ev, 'solo-start', null, i + 1)}
+                              />
+                              <div className={styles.boundaryLeg} onMouseDown={(ev) => beginBoundaryDrag(ev, 'solo-start', null, i + 1)} />
+                            </div>
+                          );
+                        }
+                      }
+                    }
+                    return <div className={styles.boundaryOverlay}>{handles}</div>;
+                  })()}
+                </div>
                 <div ref={overviewRef} className={styles.overview} />
               </div>
 
@@ -2721,15 +3318,14 @@ export default function VinylDigitizerPage() {
 
               <div className={styles.stepNav}>
                 <button className={styles.backBtn} onClick={() => setStep(2)}>← Back</button>
-                <button className={styles.nextBtn} disabled={!canExport} onClick={() => setStep(4)}>Next: Audio Export →</button>
-                <button className={styles.skipBtn} onClick={resetAll}>Start Over</button>
+                <button className={styles.nextBtn} disabled={!canExport} onClick={() => setStep(4)}>Next: Audio →</button>
               </div>
           </div>
 
           {/* ---- STEP 4 ---- */}
           {step === 4 && (
             <div className={styles.card}>
-              <h2 className={styles.cardTitle}>Step 4: Audio Export</h2>
+              <h2 className={styles.cardTitle}>Step 4: Audio</h2>
 
               {/* Format */}
               <div className={styles.formatRow}>
@@ -2857,7 +3453,22 @@ export default function VinylDigitizerPage() {
                             </td>
                             <td>{i + 1}</td>
                             <td className={styles.filenameCell}>{getFilename(i)}</td>
-                            <td>{trackNames[i] || track.name}</td>
+                            <td onClick={e => e.stopPropagation()}>
+                              <input
+                                type="text"
+                                className={styles.trackNameInput}
+                                value={trackNames[i] ?? track.name ?? ""}
+                                onChange={e => {
+                                  const v = e.target.value;
+                                  setTrackNames(prev => {
+                                    const n = [...prev];
+                                    while (n.length <= i) n.push("");
+                                    n[i] = v;
+                                    return n;
+                                  });
+                                }}
+                              />
+                            </td>
                             {discogsData && <td>{discogsData.artists?.map(a => a.name).join(", ")}</td>}
                             {discogsData && <td>{discogsData.title}</td>}
                             <td>{formatTime(track.endTime - track.startTime)}</td>
@@ -2914,9 +3525,8 @@ export default function VinylDigitizerPage() {
               )}
 
               <div className={styles.stepNav}>
-                <button className={styles.backBtn} onClick={() => setStep(3)}>← Back to Editor</button>
-                <button className={styles.nextBtn} onClick={() => setStep(5)} disabled={exportedTracks.length === 0}>Continue to Video Render →</button>
-                <button className={styles.skipBtn} onClick={resetAll}>Start Over</button>
+                <button className={styles.backBtn} onClick={() => setStep(3)}>← Back to Waveform</button>
+                <button className={styles.nextBtn} onClick={() => setStep(5)} disabled={exportedTracks.length === 0}>Next: Video →</button>
               </div>
             </div>
           )}
@@ -2924,7 +3534,7 @@ export default function VinylDigitizerPage() {
           {/* ---- STEP 5 ---- */}
           {step === 5 && (
             <div className={styles.card}>
-              <h2 className={styles.cardTitle}>Step 5: Video Render</h2>
+              <h2 className={styles.cardTitle}>Step 5: Video</h2>
 
               {/* Direct file drop zone for audio + image files */}
               <div className={styles.videoSection}>
@@ -3409,7 +4019,7 @@ export default function VinylDigitizerPage() {
               </div>
               {isRenderingVideo && (
                 <div className={styles.renderWarning}>
-                  Rendering in browser — you can navigate to YouTube Upload while this continues.
+                  Rendering in browser — you can continue interacting with the page while this completes.
                 </div>
               )}
               {videoRenderProgress !== null && (
@@ -3452,222 +4062,268 @@ export default function VinylDigitizerPage() {
 
               {message && <p className={styles.msg}>{message}</p>}
 
-              <div className={styles.stepNav}>
-                <button className={styles.backBtn} onClick={() => setStep(4)}>← Back to Audio Export</button>
-                <button className={styles.nextBtn} onClick={() => setStep(6)}>Next: YouTube Upload →</button>
-                <button className={styles.skipBtn} onClick={resetAll}>Start Over</button>
-              </div>
-            </div>
-          )}
-
-          {/* ---- STEP 6 ---- */}
-          {step === 6 && (
-            <div className={styles.card}>
-              <h2 className={styles.cardTitle}>Step 6: YouTube Upload</h2>
-
-              {/* Render status banner */}
-              {isRenderingVideo && (
-                <div className={styles.renderStatusBanner}>
-                  <div className={styles.renderStatusText}>
-                    <span className={styles.spinnerInline} /> Video rendering… {videoRenderProgress !== null ? `${(videoRenderProgress * 100).toFixed(1)}%` : ""}
-                    {formatEta() && <span className={styles.renderProgressEta}> · {formatEta()}</span>}
-                  </div>
-                  <div className={styles.renderProgressBar} style={{marginTop:8}}>
-                    <div className={styles.renderProgressFill} style={{ width: `${(videoRenderProgress || 0) * 100}%` }} />
-                  </div>
-                  <label className={styles.videoCheckLabel} style={{marginTop:8}}>
-                    <input type="checkbox" checked={autoUploadYt} onChange={e => setAutoUploadYt(e.target.checked)} />
-                    Upload to YouTube automatically when render finishes
-                  </label>
-                </div>
-              )}
-
-              {!isRenderingVideo && !renderedVideoSrc && (
-                <div className={styles.renderStatusBanner} style={{background: darkMode ? "#3a1a1a" : "#fff5f5", borderColor: darkMode ? "#6b2d2d" : "#fed7d7"}}>
-                  <span className={styles.renderStatusText} style={{color: darkMode ? "#fc8181" : "#c53030"}}>No rendered video yet. Go to Step 5 to render first.</span>
-                </div>
-              )}
-
-              {renderedVideoSrc && (
-                <div className={styles.videoPreviewSection} style={{ marginBottom: 20 }}>
-                  <video src={renderedVideoSrc} controls className={styles.videoPreview} />
-                  <button className={styles.dlAllBtn} onClick={() => { const a = document.createElement("a"); a.href = renderedVideoSrc; a.download = `${videoOutputName || projectName || "album"}.mp4`; a.click(); }}>Download Video</button>
-                  {isRenderingVideo && <div style={{ fontSize: 13, color: '#6b7280', marginTop: 6 }}>A new video is rendering — this is the previous render.</div>}
-                </div>
-              )}
-
-              {/* YouTube upload */}
-              <div className={styles.ytSection}>
-                <h3 className={styles.sectionTitle}><span style={{color:"#ff0000"}}>▶</span> Upload to YouTube</h3>
-                <YouTubeAuth compact={true} returnUrl="/vinyl-digitizer" darkMode={darkMode} getTokensRef={getTokensRef} onAuthStateChange={setYtAuthState} />
-                {ytAuthState.canAuth && (() => {
-                  const titleLen = ytUploadData.title.length;
-                  const descLen = ytUploadData.description.length;
-                  const tagsLen = ytUploadData.tags.length;
-                  const titleOver = titleLen > YT_LIMITS.title;
-                  const descOver = descLen > YT_LIMITS.description;
-                  const tagsOver = tagsLen > YT_LIMITS.tags;
-                  const anyOver = titleOver || descOver || tagsOver;
-                  return (
-                  <div className={styles.ytForm}>
-                    {/* Format options */}
-                    <div className={styles.ytFormatSection} style={{gridColumn:"1/-1"}}>
-                      <h4 className={styles.ytFormatTitle}>Format Options</h4>
-                      <div className={styles.ytFormatGrid}>
-                        <label className={styles.ytFormatLabel}>
-                          Title style
-                          <select className={`${styles.inputSmall} ${styles.ytFormatSelect}`} value={ytTitleVariation} onChange={e => { const v = parseInt(e.target.value); setYtTitleVariation(v); regenerateYtTitle(v); }}>
-                            <option value={0}>Genre-focused</option>
-                            <option value={1}>Style-focused</option>
-                            <option value={2}>Label & country</option>
-                            <option value={3}>Alt separators</option>
-                            <option value={4}>Mixed genre/style</option>
-                          </select>
-                        </label>
-                        <label className={styles.ytFormatLabel}>
-                          Timestamp format
-                          <select className={`${styles.inputSmall} ${styles.ytFormatSelect}`} value={ytTimestampFormat} onChange={e => { setYtTimestampFormat(e.target.value); setTimeout(regenerateYtMetadata, 0); }}>
-                            <option value="auto">Auto (M:SS or H:MM:SS)</option>
-                            <option value="M:SS">M:SS</option>
-                            <option value="H:MM:SS">H:MM:SS</option>
-                          </select>
-                        </label>
-                        <label className={styles.ytFormatLabel}>
-                          Separator
-                          <select className={`${styles.inputSmall} ${styles.ytFormatSelect}`} value={ytTimestampSeparator} onChange={e => { setYtTimestampSeparator(e.target.value); setTimeout(regenerateYtMetadata, 0); }}>
-                            <option value=" ">(space)</option>
-                            <option value=" - "> - (dash)</option>
-                            <option value=" | "> | (pipe)</option>
-                            <option value=" · "> · (dot)</option>
-                          </select>
-                        </label>
-                        <label className={styles.ytFormatLabel} style={{flexDirection:"row",alignItems:"center",gap:6}}>
-                          <input type="checkbox" checked={ytIncludeTrackNums} onChange={e => { setYtIncludeTrackNums(e.target.checked); setTimeout(regenerateYtMetadata, 0); }} />
-                          Track numbers
-                        </label>
+              {/* YouTube Upload Details (collapsible) */}
+              <details className={styles.ytDetailsBlock}>
+                <summary className={styles.ytDetailsSummary}>
+                  <span style={{color:"#ff0000",marginRight:6}}>▶</span>
+                  YouTube Upload Details
+                </summary>
+                <div className={styles.ytSection}>
+                  <YouTubeAuth compact={true} returnUrl="/vinyl-digitizer" darkMode={darkMode} getTokensRef={getTokensRef} onAuthStateChange={setYtAuthState} />
+                  {ytAuthState.canAuth && (() => {
+                    const titleLen = ytUploadData.title.length;
+                    const descLen = ytUploadData.description.length;
+                    const tagsLen = ytUploadData.tags.length;
+                    const titleOver = titleLen > YT_LIMITS.title;
+                    const descOver = descLen > YT_LIMITS.description;
+                    const tagsOver = tagsLen > YT_LIMITS.tags;
+                    const anyOver = titleOver || descOver || tagsOver;
+                    return (
+                    <div className={styles.ytForm}>
+                      {/* Format options */}
+                      <div className={styles.ytFormatSection} style={{gridColumn:"1/-1"}}>
+                        <h4 className={styles.ytFormatTitle}>Format Options</h4>
+                        <div className={styles.ytFormatGrid}>
+                          <label className={styles.ytFormatLabel}>
+                            Title style
+                            <select className={`${styles.inputSmall} ${styles.ytFormatSelect}`} value={ytTitleVariation} onChange={e => { const v = parseInt(e.target.value); setYtTitleVariation(v); regenerateYtTitle(v); }}>
+                              <option value={0}>Genre-focused</option>
+                              <option value={1}>Style-focused</option>
+                              <option value={2}>Label & country</option>
+                              <option value={3}>Alt separators</option>
+                              <option value={4}>Mixed genre/style</option>
+                            </select>
+                          </label>
+                          <label className={styles.ytFormatLabel}>
+                            Timestamp format
+                            <select className={`${styles.inputSmall} ${styles.ytFormatSelect}`} value={ytTimestampFormat} onChange={e => { setYtTimestampFormat(e.target.value); setTimeout(regenerateYtMetadata, 0); }}>
+                              <option value="auto">Auto (M:SS or H:MM:SS)</option>
+                              <option value="M:SS">M:SS</option>
+                              <option value="H:MM:SS">H:MM:SS</option>
+                            </select>
+                          </label>
+                          <label className={styles.ytFormatLabel}>
+                            Separator
+                            <select className={`${styles.inputSmall} ${styles.ytFormatSelect}`} value={ytTimestampSeparator} onChange={e => { setYtTimestampSeparator(e.target.value); setTimeout(regenerateYtMetadata, 0); }}>
+                              <option value=" ">(space)</option>
+                              <option value=" - "> - (dash)</option>
+                              <option value=" | "> | (pipe)</option>
+                              <option value=" · "> · (dot)</option>
+                            </select>
+                          </label>
+                          <label className={styles.ytFormatLabel} style={{flexDirection:"row",alignItems:"center",gap:6}}>
+                            <input type="checkbox" checked={ytIncludeTrackNums} onChange={e => { setYtIncludeTrackNums(e.target.checked); setTimeout(regenerateYtMetadata, 0); }} />
+                            Track numbers
+                          </label>
+                        </div>
+                        {ytTitleSuggestions.length > 0 && (
+                          <div className={styles.ytTitleSuggestions}>
+                            <span className={styles.ytFormatHint}>Title suggestions:</span>
+                            <select className={`${styles.inputSmall} ${styles.ytFormatSelect}`} style={{flex:1,minWidth:200}}
+                              value={ytUploadData.title}
+                              onChange={e => setYtUploadData(p => ({...p, title: e.target.value.slice(0, YT_LIMITS.title)}))}
+                            >
+                              <option value="">— Select a suggestion —</option>
+                              {ytTitleSuggestions.map((s, i) => (
+                                <option key={i} value={s}>{s}</option>
+                              ))}
+                            </select>
+                          </div>
+                        )}
+                        <div className={styles.ytFormatActions}>
+                          <button className={styles.selectBtn} onClick={() => regenerateYtMetadata()}>Regenerate Description</button>
+                          <button className={styles.selectBtn} onClick={() => regenerateYtTags()}>Regenerate Tags</button>
+                          <button className={styles.selectBtn} style={{background: darkMode ? "#5a2020" : "#fed7d7", color: darkMode ? "#fc8181" : "#c53030", border: "none"}} onClick={() => {
+                            setYtUploadData({ title: "", description: "", privacyStatus: "private", tags: "" });
+                            setYtTitleSuggestions([]);
+                            lastYtDiscogsUrlRef.current = null;
+                            setThumbnailFile(null);
+                            if (thumbnailPreview) { URL.revokeObjectURL(thumbnailPreview); setThumbnailPreview(null); }
+                          }}>Clear All Fields</button>
+                        </div>
                       </div>
-                      {ytTitleSuggestions.length > 0 && (
-                        <div className={styles.ytTitleSuggestions}>
-                          <span className={styles.ytFormatHint}>Title suggestions:</span>
-                          <select className={`${styles.inputSmall} ${styles.ytFormatSelect}`} style={{flex:1,minWidth:200}}
-                            value={ytUploadData.title}
-                            onChange={e => setYtUploadData(p => ({...p, title: e.target.value.slice(0, YT_LIMITS.title)}))}
-                          >
-                            <option value="">— Select a suggestion —</option>
-                            {ytTitleSuggestions.map((s, i) => (
-                              <option key={i} value={s}>{s}</option>
-                            ))}
-                          </select>
+
+                      <label className={styles.settingLabel} style={{gridColumn:"1/-1"}}>
+                        <div className={styles.ytFieldHeader}>
+                          <span>Title</span>
+                          <span className={`${styles.ytCharCount} ${titleOver ? styles.ytCharOver : ""}`}>{titleLen}/{YT_LIMITS.title}</span>
+                        </div>
+                        <input type="text" className={`${styles.input} ${titleOver ? styles.ytInputOver : ""}`} value={ytUploadData.title} onChange={e => setYtUploadData(p => ({...p, title: e.target.value}))} />
+                      </label>
+                      <div className={styles.settingLabel} style={{gridColumn:"1/-1"}}>
+                        <div className={styles.ytFieldHeader}>
+                          <span>Description</span>
+                          <span className={`${styles.ytCharCount} ${descOver ? styles.ytCharOver : ""}`}>{descLen}/{YT_LIMITS.description}</span>
+                        </div>
+                        <textarea className={`${styles.input} ${descOver ? styles.ytInputOver : ""}`} value={ytUploadData.description} onChange={e => setYtUploadData(p => ({...p, description: e.target.value}))} rows={6} style={{resize:"vertical"}} />
+                      </div>
+                      <label className={styles.settingLabel}>
+                        <div className={styles.ytFieldHeader}>
+                          <span>Tags</span>
+                          <span className={`${styles.ytCharCount} ${tagsOver ? styles.ytCharOver : ""}`}>{tagsLen}/{YT_LIMITS.tags}</span>
+                        </div>
+                        <input type="text" className={`${styles.input} ${tagsOver ? styles.ytInputOver : ""}`} value={ytUploadData.tags} onChange={e => setYtUploadData(p => ({...p, tags: e.target.value}))} placeholder="tag1, tag2" />
+                      </label>
+                      <label className={styles.settingLabel}>
+                        Visibility
+                        <select className={styles.input} value={ytUploadData.privacyStatus} onChange={e => setYtUploadData(p => ({...p, privacyStatus: e.target.value}))}>
+                          <option value="private">Private</option>
+                          <option value="unlisted">Unlisted</option>
+                          <option value="public">Public</option>
+                        </select>
+                      </label>
+                      <div style={{gridColumn:"1/-1"}}>
+                        <span className={styles.label}>Thumbnail (optional)</span>
+                        <div style={{display:"flex",alignItems:"center",gap:12,marginTop:6}}>
+                          <div onClick={() => thumbnailInputRef.current?.click()} className={styles.thumbDropzone}>
+                            {thumbnailPreview ? <img src={thumbnailPreview} alt="thumb" style={{width:"100%",height:"100%",objectFit:"cover"}} /> : <span style={{fontSize:11,color:"#a0aec0",textAlign:"center",padding:8}}>Click to upload</span>}
+                          </div>
+                          <input ref={thumbnailInputRef} type="file" accept="image/*" style={{display:"none"}}
+                            onChange={e => {
+                              const f = e.target.files?.[0]; if (!f) return;
+                              if (thumbnailPreview) URL.revokeObjectURL(thumbnailPreview);
+                              setThumbnailFile(f); setThumbnailPreview(URL.createObjectURL(f));
+                            }} />
+                          {thumbnailFile && <button className={styles.selectBtn} onClick={() => { setThumbnailFile(null); if(thumbnailPreview) URL.revokeObjectURL(thumbnailPreview); setThumbnailPreview(null); }}>Remove</button>}
+                        </div>
+                      </div>
+                      {anyOver && (
+                        <div className={styles.ytLimitWarning} style={{gridColumn:"1/-1"}}>
+                          {titleOver && <span>Title exceeds 100 characters. </span>}
+                          {descOver && <span>Description exceeds 5,000 characters. </span>}
+                          {tagsOver && <span>Tags exceed 500 characters. </span>}
+                          Shorten the fields highlighted in red before uploading.
                         </div>
                       )}
-                      <div className={styles.ytFormatActions}>
-                        <button className={styles.selectBtn} onClick={() => regenerateYtMetadata()}>Regenerate Description</button>
-                        <button className={styles.selectBtn} onClick={() => regenerateYtTags()}>Regenerate Tags</button>
-                        <button className={styles.selectBtn} style={{background: darkMode ? "#5a2020" : "#fed7d7", color: darkMode ? "#fc8181" : "#c53030", border: "none"}} onClick={() => {
-                          setYtUploadData({ title: "", description: "", privacyStatus: "private", tags: "" });
-                          setYtTitleSuggestions([]);
-                          lastYtDiscogsUrlRef.current = null;
-                          setThumbnailFile(null);
-                          if (thumbnailPreview) { URL.revokeObjectURL(thumbnailPreview); setThumbnailPreview(null); }
-                        }}>Clear All Fields</button>
-                      </div>
-                    </div>
-
-                    <label className={styles.settingLabel} style={{gridColumn:"1/-1"}}>
-                      <div className={styles.ytFieldHeader}>
-                        <span>Title</span>
-                        <span className={`${styles.ytCharCount} ${titleOver ? styles.ytCharOver : ""}`}>{titleLen}/{YT_LIMITS.title}</span>
-                      </div>
-                      <input type="text" className={`${styles.input} ${titleOver ? styles.ytInputOver : ""}`} value={ytUploadData.title} onChange={e => setYtUploadData(p => ({...p, title: e.target.value}))} />
-                    </label>
-                    <div className={styles.settingLabel} style={{gridColumn:"1/-1"}}>
-                      <div className={styles.ytFieldHeader}>
-                        <span>Description</span>
-                        <span className={`${styles.ytCharCount} ${descOver ? styles.ytCharOver : ""}`}>{descLen}/{YT_LIMITS.description}</span>
-                      </div>
-                      <textarea className={`${styles.input} ${descOver ? styles.ytInputOver : ""}`} value={ytUploadData.description} onChange={e => setYtUploadData(p => ({...p, description: e.target.value}))} rows={6} style={{resize:"vertical"}} />
-                    </div>
-                    <label className={styles.settingLabel}>
-                      <div className={styles.ytFieldHeader}>
-                        <span>Tags</span>
-                        <span className={`${styles.ytCharCount} ${tagsOver ? styles.ytCharOver : ""}`}>{tagsLen}/{YT_LIMITS.tags}</span>
-                      </div>
-                      <input type="text" className={`${styles.input} ${tagsOver ? styles.ytInputOver : ""}`} value={ytUploadData.tags} onChange={e => setYtUploadData(p => ({...p, tags: e.target.value}))} placeholder="tag1, tag2" />
-                    </label>
-                    <label className={styles.settingLabel}>
-                      Visibility
-                      <select className={styles.input} value={ytUploadData.privacyStatus} onChange={e => setYtUploadData(p => ({...p, privacyStatus: e.target.value}))}>
-                        <option value="private">Private</option>
-                        <option value="unlisted">Unlisted</option>
-                        <option value="public">Public</option>
-                      </select>
-                    </label>
-                    <div style={{gridColumn:"1/-1"}}>
-                      <span className={styles.label}>Thumbnail (optional)</span>
-                      <div style={{display:"flex",alignItems:"center",gap:12,marginTop:6}}>
-                        <div onClick={() => thumbnailInputRef.current?.click()} className={styles.thumbDropzone}>
-                          {thumbnailPreview ? <img src={thumbnailPreview} alt="thumb" style={{width:"100%",height:"100%",objectFit:"cover"}} /> : <span style={{fontSize:11,color:"#a0aec0",textAlign:"center",padding:8}}>Click to upload</span>}
-                        </div>
-                        <input ref={thumbnailInputRef} type="file" accept="image/*" style={{display:"none"}}
-                          onChange={e => {
-                            const f = e.target.files?.[0]; if (!f) return;
-                            if (thumbnailPreview) URL.revokeObjectURL(thumbnailPreview);
-                            setThumbnailFile(f); setThumbnailPreview(URL.createObjectURL(f));
-                          }} />
-                        {thumbnailFile && <button className={styles.selectBtn} onClick={() => { setThumbnailFile(null); if(thumbnailPreview) URL.revokeObjectURL(thumbnailPreview); setThumbnailPreview(null); }}>Remove</button>}
-                      </div>
-                    </div>
-                    {anyOver && (
-                      <div className={styles.ytLimitWarning} style={{gridColumn:"1/-1"}}>
-                        {titleOver && <span>Title exceeds 100 characters. </span>}
-                        {descOver && <span>Description exceeds 5,000 characters. </span>}
-                        {tagsOver && <span>Tags exceed 500 characters. </span>}
-                        Shorten the fields highlighted in red before uploading.
-                      </div>
-                    )}
-                    <div style={{gridColumn:"1/-1"}}>
-                      <button onClick={() => uploadToYouTube()} disabled={ytUploading || (!renderedVideoSrc && !isRenderingVideo) || anyOver || isRenderingVideo} className={styles.exportBtn} style={{width:"100%",background: ytUploading ? undefined : (anyOver || isRenderingVideo || !renderedVideoSrc) ? "#cbd5e0" : "#ff0000"}}>
-                        {ytUploading
-                          ? (ytUploadProgress < 100 ? `Uploading… ${ytUploadProgress}%` : <span className={styles.ytProcessing}>Processing</span>)
-                          : isRenderingVideo
-                            ? `Rendering… ${videoRenderProgress !== null ? `${(videoRenderProgress * 100).toFixed(0)}%` : ""}`
-                            : !renderedVideoSrc
-                              ? "No video rendered"
-                              : "Upload to YouTube"}
-                      </button>
-                    </div>
-                    {ytUploading && (
                       <div style={{gridColumn:"1/-1"}}>
-                        <div className={styles.progressBar}><div className={styles.progressFill} style={{width:`${ytUploadProgress ?? 0}%`,background: ytUploadProgress < 100 ? "#ff0000" : "#48bb78"}} /></div>
+                        <button
+                          onClick={() => {
+                            // While rendering, clicking queues the upload to fire as soon as the render completes.
+                            if (isRenderingVideo && !renderedVideoSrc) {
+                              setAutoUploadYt(prev => !prev);
+                              return;
+                            }
+                            uploadToYouTube();
+                          }}
+                          disabled={ytUploading || (!renderedVideoSrc && !isRenderingVideo) || anyOver}
+                          className={styles.exportBtn}
+                          style={{
+                            width: "100%",
+                            background: ytUploading
+                              ? undefined
+                              : anyOver
+                                ? "#cbd5e0"
+                                : autoUploadYt && isRenderingVideo
+                                  ? "#3182ce"
+                                  : (!renderedVideoSrc && !isRenderingVideo)
+                                    ? "#cbd5e0"
+                                    : "#ff0000",
+                          }}
+                        >
+                          {ytUploading
+                            ? (ytUploadProgress < 100 ? `Uploading… ${ytUploadProgress}%` : <span className={styles.ytProcessing}>Processing</span>)
+                            : isRenderingVideo && !renderedVideoSrc
+                              ? (autoUploadYt
+                                  ? `✓ Queued — will upload when render finishes${videoRenderProgress !== null ? ` (${(videoRenderProgress * 100).toFixed(0)}%)` : ""}`
+                                  : `Queue upload (rendering ${videoRenderProgress !== null ? `${(videoRenderProgress * 100).toFixed(0)}%` : "…"})`)
+                              : !renderedVideoSrc
+                                ? "No video rendered"
+                                : "Upload to YouTube"}
+                        </button>
+                        {isRenderingVideo && !renderedVideoSrc && autoUploadYt && (
+                          <div style={{ fontSize: 12, color: "#3182ce", marginTop: 6, textAlign: "center" }}>
+                            Upload will start automatically once the video finishes rendering. Click the button again to cancel.
+                          </div>
+                        )}
                       </div>
-                    )}
-                    {ytUploadError && <p className={styles.errorMsg} style={{gridColumn:"1/-1"}}>{ytUploadError}</p>}
-                    {ytUploadResult && (() => {
-                      const vid = ytUploadResult.videoId || ytUploadResult.id || ytUploadResult.snippet?.resourceId?.videoId;
-                      return (
-                        <div className={styles.ytResult} style={{gridColumn:"1/-1"}}>
-                          ✅ Uploaded successfully!
-                          {vid && (
-                            <div style={{marginTop: 8}}>
-                              <a href={`https://youtube.com/watch?v=${vid}`} target="_blank" rel="noreferrer" className={styles.ytVideoLink}>
-                                https://youtube.com/watch?v={vid}
-                              </a>
-                            </div>
-                          )}
+                      {ytUploading && (
+                        <div style={{gridColumn:"1/-1"}}>
+                          <div className={styles.progressBar}><div className={styles.progressFill} style={{width:`${ytUploadProgress ?? 0}%`,background: ytUploadProgress < 100 ? "#ff0000" : "#48bb78"}} /></div>
                         </div>
-                      );
-                    })()}
-                  </div>
-                  );
-                })()}
-              </div>
+                      )}
+                      {ytUploadAuthError && (
+                        <div className={styles.ytAuthErrorCard} style={{gridColumn:"1/-1"}}>
+                          <div className={styles.ytAuthErrorTitle}>
+                            ⚠️ YouTube sign-in expired — upload was rejected
+                          </div>
+                          <div className={styles.ytAuthErrorBody}>
+                            Google rejected the upload because your stored YouTube credentials are no longer valid
+                            <span className={styles.ytAuthErrorReason}> ({ytUploadAuthError.reason})</span>.
+                            This usually happens after a long break, a password change, or if you revoked access from your
+                            Google account. <strong>Your video was not uploaded.</strong>
+                          </div>
+                          <ul className={styles.ytAuthErrorList}>
+                            <li>Click <em>Sign in to YouTube again</em> below to refresh your credentials.</li>
+                            <li>Make sure to grant the same YouTube upload permission when prompted.</li>
+                            <li>Once you're signed in again, return here and click <em>Upload to YouTube</em>.</li>
+                          </ul>
+                          <div className={styles.ytAuthErrorActions}>
+                            <button
+                              className={styles.ytAuthErrorPrimaryBtn}
+                              onClick={async () => {
+                                try {
+                                  const res = await fetch(`${apiBaseURL()}/youtube/getAuthUrl`, { credentials: 'include' });
+                                  if (res.ok) {
+                                    const data = await res.json();
+                                    if (data?.url) {
+                                      try { localStorage.setItem('youtube_auth_return_url', '/vinyl-digitizer'); } catch {}
+                                      window.location.href = data.url;
+                                      return;
+                                    }
+                                  }
+                                  setYtUploadError('Could not fetch the YouTube sign-in URL. Try the Sign in button above.');
+                                } catch (e) {
+                                  setYtUploadError(`Could not start YouTube sign-in: ${e.message}`);
+                                }
+                              }}
+                            >
+                              Sign in to YouTube again
+                            </button>
+                            <button
+                              className={styles.ytAuthErrorSecondaryBtn}
+                              onClick={() => setYtUploadAuthError(null)}
+                            >
+                              Dismiss
+                            </button>
+                          </div>
+                        </div>
+                      )}
+                      {ytUploadError && !ytUploadAuthError && (
+                        <div className={styles.ytErrorCard} style={{gridColumn:"1/-1"}}>
+                          <div className={styles.ytErrorTitle}>Upload failed</div>
+                          <div className={styles.ytErrorBody}>{ytUploadError}</div>
+                          <div className={styles.ytErrorHint}>
+                            If you keep seeing this, try clearing your YouTube auth and signing in again.
+                          </div>
+                        </div>
+                      )}
+                      {ytUploadResult && (() => {
+                        const vid = ytUploadResult.videoId || ytUploadResult.id || ytUploadResult.snippet?.resourceId?.videoId;
+                        return (
+                          <div className={styles.ytResult} style={{gridColumn:"1/-1"}}>
+                            ✅ Uploaded successfully!
+                            {vid && (
+                              <div style={{marginTop: 8}}>
+                                <a href={`https://youtube.com/watch?v=${vid}`} target="_blank" rel="noreferrer" className={styles.ytVideoLink}>
+                                  https://youtube.com/watch?v={vid}
+                                </a>
+                              </div>
+                            )}
+                          </div>
+                        );
+                      })()}
+                    </div>
+                    );
+                  })()}
+                </div>
+              </details>
 
               <div className={styles.stepNav}>
-                <button className={styles.backBtn} onClick={() => setStep(5)}>← Back to Video Render</button>
-                <button className={styles.skipBtn} onClick={resetAll}>Start Over</button>
+                <button className={styles.backBtn} onClick={() => setStep(4)}>← Back to Audio</button>
               </div>
             </div>
           )}
+
         </div>
 
           {/* Image Add Modal */}

--- a/app/(main)/vinyl-digitizer/vinyl-digitizer.module.css
+++ b/app/(main)/vinyl-digitizer/vinyl-digitizer.module.css
@@ -472,7 +472,10 @@
 }
 .playBtnSmall:hover:not(:disabled) { transform: scale(1.1); box-shadow: 0 3px 10px rgba(102,126,234,0.5); }
 .playBtnSmall:disabled { background: #cbd5e0; cursor: not-allowed; box-shadow: none; }
-.timeLabel { font-size: 0.82rem; font-weight: 600; color: #000000; font-variant-numeric: tabular-nums; white-space: nowrap; }
+.timeLabel { font-size: 0.82rem; font-weight: 600; color: #000000; font-variant-numeric: tabular-nums; white-space: nowrap; display: inline-flex; align-items: baseline; gap: 4px; }
+.timeCurrent { display: inline-block; text-align: right; font-variant-numeric: tabular-nums; }
+.timeSep { opacity: 0.6; }
+.timeDuration { display: inline-block; font-variant-numeric: tabular-nums; }
 .volSlider { width: 64px; height: 4px; -webkit-appearance: none; appearance: none; background: #e2e8f0; border-radius: 2px; cursor: pointer; }
 .volSlider::-webkit-slider-thumb { -webkit-appearance: none; width: 13px; height: 13px; border-radius: 50%; background: #667eea; cursor: pointer; box-shadow: 0 1px 3px rgba(0,0,0,0.2); }
 .splitAddBtn {
@@ -544,10 +547,78 @@
   border-radius: 0 0 8px 8px;
   margin-bottom: 0.5rem;
 }
+.zoomviewWrap {
+  position: relative;
+}
 .zoomview {
   height: 200px;
   background: #0f1117;
 }
+.boundaryOverlay {
+  position: absolute;
+  top: 0;
+  left: 0;
+  right: 0;
+  height: 100%;
+  pointer-events: none;
+  z-index: 5;
+}
+.boundaryHandle {
+  position: absolute;
+  top: 0;
+  width: 1px;
+  height: 100%;
+  transform: translateX(-50%);
+  pointer-events: none;
+}
+.boundaryBar {
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 22px;
+  height: 12px;
+  background: #fbbf24;
+  border: 1px solid #b45309;
+  border-radius: 2px;
+  cursor: ew-resize;
+  pointer-events: auto;
+  box-shadow: 0 1px 2px rgba(0,0,0,0.4);
+}
+.boundaryBar:hover { background: #fcd34d; }
+.boundaryLeg {
+  position: absolute;
+  top: 12px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 14px;
+  height: calc(100% - 12px);
+  cursor: col-resize;
+  pointer-events: auto;
+}
+.boundaryLeg::before {
+  content: '';
+  position: absolute;
+  top: 0;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 2px;
+  height: 100%;
+  background: rgba(251, 191, 36, 0.55);
+}
+.boundaryLeg:hover::before { background: rgba(253, 211, 80, 0.85); width: 3px; }
+.boundaryLegLeft::before {
+  background: rgba(251, 191, 36, 0.9);
+  box-shadow: -3px 0 0 rgba(251, 191, 36, 0.45);
+}
+.boundaryLegRight::before {
+  background: rgba(251, 191, 36, 0.9);
+  box-shadow: 3px 0 0 rgba(251, 191, 36, 0.45);
+}
+.boundarySolo .boundaryBar { background: #93c5fd; border-color: #1d4ed8; }
+.boundarySolo .boundaryBar:hover { background: #bfdbfe; }
+.boundarySolo .boundaryLeg::before { background: rgba(147, 197, 253, 0.55); }
+.boundarySolo .boundaryLeg:hover::before { background: rgba(191, 219, 254, 0.85); }
 .overview {
   height: 60px;
   background: #0f1117;
@@ -639,6 +710,82 @@
 .removeBtn { background: none; border: none; color: #e53e3e; cursor: pointer; font-size: 0.9rem; font-weight: 700; padding: 0 2px; line-height: 1; opacity: 0.7; }
 .removeBtn:hover { opacity: 1; }
 
+.uploadedFilesSection { margin-top: 1.25rem; }
+.uploadedFilesSection .sectionTitle {
+  font-size: 0.85rem;
+  font-weight: 700;
+  color: #2d3748;
+  margin: 0 0 0.5rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.sectionHint { font-size: 0.75rem; font-weight: 500; color: #718096; text-transform: none; letter-spacing: 0; margin-left: 6px; }
+.rowActiveFile { background: rgba(102, 126, 234, 0.08); }
+.activeBadge {
+  display: inline-block;
+  background: #48bb78;
+  color: white;
+  font-size: 0.7rem;
+  font-weight: 700;
+  padding: 2px 8px;
+  border-radius: 10px;
+  white-space: nowrap;
+}
+.uploadedThumb {
+  width: 42px;
+  height: 42px;
+  object-fit: cover;
+  border-radius: 4px;
+  border: 1px solid #e2e8f0;
+  display: block;
+}
+.uploadedThumbPlaceholder {
+  width: 42px;
+  height: 42px;
+  border-radius: 4px;
+  border: 1px dashed #cbd5e0;
+  background: #f7fafc;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+.fileStatusLoading {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  font-size: 0.78rem;
+  color: #4a5568;
+}
+.fileStatusReady {
+  display: inline-block;
+  font-size: 0.78rem;
+  font-weight: 600;
+  color: #2f855a;
+}
+.fileStatusIdle {
+  display: inline-block;
+  font-size: 0.78rem;
+  color: #a0aec0;
+}
+.fileInfoAllReady {
+  background: #c6f6d5;
+  border: 1px solid #9ae6b4;
+  color: #22543d;
+  font-weight: 700;
+  padding: 8px 12px;
+  border-radius: 6px;
+  margin-top: 1rem;
+}
+:global(.darkContent) .uploadedThumbPlaceholder { background: #1e1e2e; border-color: #555; }
+:global(.darkContent) .fileStatusLoading { color: #cbd5e0; }
+:global(.darkContent) .fileStatusReady { color: #68d391; }
+:global(.darkContent) .fileStatusIdle { color: #718096; }
+:global(.darkContent) .fileInfoAllReady { background: rgba(72, 187, 120, 0.15); border-color: #38a169; color: #9ae6b4; }
+:global(.darkContent) .uploadedFilesSection .sectionTitle { color: #f7fafc; }
+:global(.darkContent) .sectionHint { color: #a0aec0; }
+:global(.darkContent) .rowActiveFile { background: rgba(102, 126, 234, 0.18); }
+:global(.darkContent) .uploadedThumb { border-color: #555; }
+
 /* ---- Table ---- */
 .tableWrap { overflow-x: auto; margin: 0.5rem 0; }
 .table { width: 100%; border-collapse: collapse; font-size: 0.82rem; background: white; border-radius: 6px; overflow: hidden; box-shadow: 0 1px 4px rgba(0,0,0,0.04); }
@@ -686,7 +833,18 @@
 .metaBadge { background: rgba(255,255,255,0.2); border-radius: 4px; padding: 1px 6px; font-size: 0.68rem; font-weight: 700; }
 .previewSection { margin-bottom: 0.75rem; }
 .sectionTitle { font-size: 0.88rem; font-weight: 700; color: #000000; margin: 0 0 0.5rem; }
-.filenameCell { font-family: monospace; font-size: 0.75rem; color: #000000; max-width: 220px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.filenameCell { font-family: monospace; font-size: 0.75rem; color: #000000; max-width: 220px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; cursor: pointer; }
+.filenameCell:hover { background: rgba(102, 126, 234, 0.06); }
+.filenameCellExpanded {
+  max-width: none;
+  white-space: normal;
+  word-break: break-all;
+  overflow: visible;
+  text-overflow: clip;
+  background: rgba(102, 126, 234, 0.08);
+}
+.timeCell { font-family: ui-monospace, SFMono-Regular, monospace; font-size: 0.78rem; white-space: nowrap; }
+:global(.darkContent) .filenameCellExpanded { background: rgba(102, 126, 234, 0.18); }
 .exportRow {
   display: flex;
   align-items: center;
@@ -1798,6 +1956,42 @@
 .videoPreviewSection { margin: 1rem 0; display: flex; flex-direction: column; gap: 0.75rem; align-items: flex-start; }
 .videoPreview { width: 100%; max-width: 640px; max-height: 360px; border-radius: 8px; border: 1px solid #e2e8f0; object-fit: contain; background: #000; display: block; }
 .ytSection { margin-top: 1.5rem; border-top: 1px solid #e2e8f0; padding-top: 1.25rem; }
+.ytDetailsBlock {
+  margin-top: 1.25rem;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  background: rgba(255,0,0,0.02);
+  overflow: hidden;
+}
+.ytDetailsSummary {
+  cursor: pointer;
+  list-style: none;
+  padding: 0.75rem 1rem;
+  font-weight: 600;
+  font-size: 0.95rem;
+  user-select: none;
+  display: flex;
+  align-items: center;
+  background: rgba(255,0,0,0.04);
+}
+.ytDetailsSummary::-webkit-details-marker { display: none; }
+.ytDetailsSummary::after {
+  content: "▾";
+  margin-left: auto;
+  font-size: 0.8rem;
+  opacity: 0.6;
+  transition: transform 0.15s;
+}
+.ytDetailsBlock[open] .ytDetailsSummary::after { transform: rotate(180deg); }
+.ytDetailsBlock[open] .ytDetailsSummary { border-bottom: 1px solid #e2e8f0; }
+.ytDetailsBlock .ytSection {
+  margin-top: 0;
+  border-top: none;
+  padding: 1rem 1rem 1.25rem;
+}
+:global(.darkContent) .ytDetailsBlock { border-color: #444; background: rgba(255,0,0,0.05); }
+:global(.darkContent) .ytDetailsSummary { background: rgba(255,0,0,0.08); color: #fff; }
+:global(.darkContent) .ytDetailsBlock[open] .ytDetailsSummary { border-bottom-color: #444; }
 .ytForm { display: grid; grid-template-columns: repeat(auto-fit, minmax(250px, 1fr)); gap: 0.75rem; margin-top: 1rem; }
 .thumbDropzone { width: 120px; height: 68px; border: 2px dashed #cbd5e0; border-radius: 6px; cursor: pointer; overflow: hidden; display: flex; align-items: center; justify-content: center; background: #f7fafc; flex-shrink: 0; }
 .ytResult { padding: 10px 14px; background: #f0fff4; border: 1px solid #c6f6d5; border-radius: 6px; font-size: 0.9rem; font-weight: 600; color: #276749; }
@@ -1838,6 +2032,117 @@
   border-color: #e53e3e !important;
   box-shadow: 0 0 0 2px rgba(229, 62, 62, 0.2) !important;
 }
+.audioSwitcher {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 10px;
+  margin-bottom: 0.75rem;
+  background: #f7fafc;
+  border: 1px solid #e2e8f0;
+  border-radius: 8px;
+  flex-wrap: wrap;
+}
+.audioSwitcherLabel {
+  font-size: 0.78rem;
+  font-weight: 700;
+  color: #4a5568;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+}
+.audioSwitcherList { display: flex; flex-wrap: wrap; gap: 6px; flex: 1; min-width: 0; }
+.audioSwitcherItem {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 12px;
+  font-size: 0.82rem;
+  background: white;
+  color: #2d3748;
+  border: 1px solid #cbd5e0;
+  border-radius: 16px;
+  cursor: pointer;
+  max-width: 260px;
+  transition: all 0.15s;
+}
+.audioSwitcherItem:hover { border-color: #667eea; background: #edf2ff; }
+.audioSwitcherItemActive {
+  background: linear-gradient(135deg, #667eea, #764ba2);
+  border-color: #667eea;
+  color: white;
+  font-weight: 600;
+}
+.audioSwitcherName { overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.audioSwitcherBadge { font-weight: 700; }
+:global(.darkContent) .audioSwitcher { background: #1e1e2e; border-color: #444; }
+:global(.darkContent) .audioSwitcherLabel { color: #cbd5e0; }
+:global(.darkContent) .audioSwitcherItem { background: #2a2a3d; color: #f7fafc; border-color: #555; }
+:global(.darkContent) .audioSwitcherItem:hover { background: rgba(102, 126, 234, 0.2); border-color: #667eea; }
+
+.audioPickerCard {
+  background: #fffaf0;
+  border: 1px solid #f6ad55;
+  border-left: 4px solid #dd6b20;
+  border-radius: 8px;
+  padding: 12px 14px;
+  margin-bottom: 1rem;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.audioPickerHeader {
+  font-weight: 700;
+  color: #7b341e;
+  font-size: 0.92rem;
+}
+.audioPickerList {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+.audioPickerItem {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  padding: 8px 12px;
+  background: white;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  text-align: left;
+  transition: all 0.15s;
+}
+.audioPickerItem:hover { border-color: #f6ad55; background: #fff7e6; }
+.audioPickerItemActive {
+  border-color: #dd6b20;
+  background: #fff7e6;
+  box-shadow: 0 0 0 2px rgba(221, 107, 32, 0.18);
+}
+.audioPickerName { flex: 1; font-weight: 600; color: #2d3748; word-break: break-all; }
+.audioPickerSize { font-size: 0.78rem; color: #718096; flex-shrink: 0; }
+.audioPickerBadge {
+  font-size: 0.7rem;
+  font-weight: 700;
+  color: white;
+  background: #dd6b20;
+  padding: 2px 8px;
+  border-radius: 10px;
+  flex-shrink: 0;
+}
+.audioPickerActions { display: flex; gap: 8px; flex-wrap: wrap; }
+:global(.darkContent) .audioPickerCard {
+  background: rgba(221, 107, 32, 0.12);
+  border-color: #c87831;
+  color: #f7fafc;
+}
+:global(.darkContent) .audioPickerHeader { color: #fbd38d; }
+:global(.darkContent) .audioPickerItem { background: #2a2a3d; border-color: #555; color: #f7fafc; }
+:global(.darkContent) .audioPickerItem:hover { background: rgba(221, 107, 32, 0.18); border-color: #f6ad55; }
+:global(.darkContent) .audioPickerItemActive { background: rgba(221, 107, 32, 0.25); border-color: #fbd38d; }
+:global(.darkContent) .audioPickerName { color: #f7fafc; }
+:global(.darkContent) .audioPickerSize { color: #a0aec0; }
+
 .ytLimitWarning {
   background: #fff5f5;
   border: 1px solid #feb2b2;
@@ -1847,6 +2152,74 @@
   font-size: 0.8rem;
   font-weight: 500;
 }
+.ytAuthErrorCard {
+  background: #fff5f5;
+  border: 1px solid #fc8181;
+  border-left: 4px solid #c53030;
+  border-radius: 8px;
+  padding: 14px 16px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  color: #2d3748;
+}
+.ytAuthErrorTitle { font-weight: 700; color: #c53030; font-size: 0.95rem; }
+.ytAuthErrorBody { font-size: 0.85rem; line-height: 1.45; }
+.ytAuthErrorReason { font-family: ui-monospace, SFMono-Regular, monospace; font-size: 0.8rem; color: #742a2a; }
+.ytAuthErrorList { margin: 0; padding-left: 1.1rem; font-size: 0.82rem; line-height: 1.55; color: #2d3748; }
+.ytAuthErrorList li { margin-bottom: 2px; }
+.ytAuthErrorActions { display: flex; gap: 10px; flex-wrap: wrap; margin-top: 4px; }
+.ytAuthErrorPrimaryBtn {
+  background: #ff0000;
+  color: white;
+  border: none;
+  padding: 8px 16px;
+  border-radius: 6px;
+  font-weight: 700;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+.ytAuthErrorPrimaryBtn:hover { background: #d40000; }
+.ytAuthErrorSecondaryBtn {
+  background: transparent;
+  color: #c53030;
+  border: 1px solid #feb2b2;
+  padding: 8px 14px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.82rem;
+}
+.ytAuthErrorSecondaryBtn:hover { background: #fff5f5; }
+.ytErrorCard {
+  background: #fff5f5;
+  border: 1px solid #feb2b2;
+  border-radius: 6px;
+  padding: 10px 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.ytErrorTitle { font-weight: 700; color: #c53030; font-size: 0.85rem; }
+.ytErrorBody { font-size: 0.82rem; color: #742a2a; font-family: ui-monospace, SFMono-Regular, monospace; word-break: break-word; }
+.ytErrorHint { font-size: 0.78rem; color: #718096; }
+:global(.darkContent) .ytAuthErrorCard,
+:global(.darkContent) .ytErrorCard {
+  background: rgba(220, 38, 38, 0.1);
+  border-color: #b14b56;
+  color: #f7fafc;
+}
+:global(.darkContent) .ytAuthErrorTitle,
+:global(.darkContent) .ytErrorTitle { color: #fc8181; }
+:global(.darkContent) .ytAuthErrorBody,
+:global(.darkContent) .ytAuthErrorList { color: #f7fafc; }
+:global(.darkContent) .ytErrorBody { color: #fed7d7; }
+:global(.darkContent) .ytAuthErrorReason { color: #fed7d7; }
+:global(.darkContent) .ytErrorHint { color: #a0aec0; }
+:global(.darkContent) .ytAuthErrorSecondaryBtn {
+  color: #fc8181;
+  border-color: #b14b56;
+}
+:global(.darkContent) .ytAuthErrorSecondaryBtn:hover { background: rgba(220, 38, 38, 0.15); }
 .ytProcessing {
   display: inline-flex;
   align-items: center;
@@ -2362,13 +2735,50 @@
   .stepLabel { font-size: 0.72rem; }
 }
 @media (max-width: 768px) {
-  .page { padding: 0.5rem; }
-  .header { flex-direction: column; }
+  .page {
+    padding: 0;
+    max-width: 100%;
+    border-radius: 0;
+    border-left: none;
+    border-right: none;
+  }
+  .header { flex-direction: column; padding: 0.75rem; border-radius: 0; border-left: none; border-right: none; }
   .headerRight { width: 100%; }
   .projectNameInput { flex: 1; }
-  .stepBar { gap: 0; padding: 0.5rem; }
-  .stepLabel { display: none; }
-  .body { flex-direction: column; }
+  .stepBarWrap { margin-bottom: 0.5rem; }
+  .stepBar {
+    gap: 0;
+    padding: 0.5rem;
+    border-radius: 0;
+    border-left: none;
+    border-right: none;
+    overflow-x: hidden;
+  }
+  .stepItem {
+    gap: 4px;
+    min-width: 0;
+    flex: 1 1 0;
+  }
+  .stepCircle { flex-shrink: 0; }
+  .stepLabel {
+    font-size: 0.7rem;
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+    min-width: 0;
+  }
+  .stepLine {
+    width: 12px;
+    margin: 0 4px;
+    flex-shrink: 0;
+  }
+  .body { gap: 0.5rem; }
+  .card {
+    padding: 0.75rem;
+    border-radius: 0;
+    border-left: none;
+    border-right: none;
+  }
   .historySidebar { width: 100%; max-height: none; }
   .exportGrid { grid-template-columns: 1fr; }
   .waveToolbar { gap: 0.35rem; }

--- a/app/(main)/youtube/page.js
+++ b/app/(main)/youtube/page.js
@@ -31,6 +31,7 @@ function YouTubeAuthPageInner() {
   const [debugLog, setDebugLog] = useState([]);
   const [canAuth, setCanAuth] = useState(false);
   const [isRedirecting, setIsRedirecting] = useState(false);
+  const [popupComplete, setPopupComplete] = useState(false);
 
   const getTokensRef = useRef(null);
   const params = useSearchParams();
@@ -44,7 +45,9 @@ function YouTubeAuthPageInner() {
     console.log(`[YT Debug][${type.toUpperCase()}] ${msg}`);
   };
 
-  // On OAuth redirect: store code, check for returnUrl, redirect
+  // On OAuth redirect: store code. If this tab was opened as a popup from another
+  // page (popup flow), show a "you can close this tab" message instead of
+  // navigating — the original tab will pick up the new auth via the storage event.
   useEffect(() => {
     if (authCode && scope) {
       try {
@@ -53,6 +56,13 @@ function YouTubeAuthPageInner() {
         localStorage.setItem('youtube_auth_set_time', Date.now().toString());
       } catch (err) {
         console.error('Failed to save YouTube auth code:', err);
+      }
+      let popupFlow = false;
+      try { popupFlow = localStorage.getItem('youtube_auth_popup_flow') === '1'; } catch {}
+      if (popupFlow) {
+        try { localStorage.removeItem('youtube_auth_popup_flow'); } catch {}
+        setPopupComplete(true);
+        return;
       }
       const returnUrl = localStorage.getItem('youtube_auth_return_url');
       if (returnUrl && returnUrl !== '/youtube') {
@@ -64,6 +74,27 @@ function YouTubeAuthPageInner() {
       }
     }
   }, [authCode, scope, router]);
+
+  if (popupComplete) {
+    return (
+      <div style={{ padding: '60px 24px', textAlign: 'center', maxWidth: 480, margin: '0 auto', color: t.text, background: t.bg, minHeight: '60vh' }}>
+        <div style={{ fontSize: 56, marginBottom: 16 }}>✅</div>
+        <h2 style={{ margin: '0 0 12px', fontSize: 22, color: t.text }}>YouTube sign-in complete</h2>
+        <p style={{ fontSize: 15, color: t.text, marginBottom: 8 }}>
+          You can safely close this tab. Your original page should already show that you are signed in.
+        </p>
+        <p style={{ fontSize: 13, color: darkMode ? '#a0aec0' : '#666', marginTop: 24 }}>
+          If the original page doesn&apos;t update automatically, refresh it.
+        </p>
+        <button
+          onClick={() => { try { window.close(); } catch {} }}
+          style={{ marginTop: 24, padding: '10px 22px', fontSize: 14, fontWeight: 600, background: '#48bb78', color: 'white', border: 'none', borderRadius: 6, cursor: 'pointer' }}
+        >
+          Close this tab
+        </button>
+      </div>
+    );
+  }
 
   // Show a redirecting message instead of the full page
   if (isRedirecting) {

--- a/app/utils/musicMetadata.js
+++ b/app/utils/musicMetadata.js
@@ -107,8 +107,26 @@ export function extractTagsFromDiscogs(response, filenames = []) {
 }
 
 /**
+ * Sanitize a single tag for YouTube. Strips characters that cause
+ * invalidVideoMetadata errors (angle brackets, quotes, control chars),
+ * collapses whitespace, and enforces the 30-char per-tag limit.
+ */
+export function sanitizeYouTubeTag(tag) {
+  if (tag == null) return '';
+  return String(tag)
+    .replace(/[<>"']/g, '')
+    .replace(/[\x00-\x1F\x7F]/g, '')
+    .replace(/[,;]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 30)
+    .trim();
+}
+
+/**
  * Build a comma-separated tag string from categorized tags + per-category filters.
  * filters: { artists: { enabled, sliderValue }, album: { ... }, ... }
+ * Tags are sanitized to remove YouTube-illegal characters and enforce length limits.
  */
 export function buildTagString(tags, filters) {
   const all = new Set();
@@ -117,7 +135,10 @@ export function buildTagString(tags, filters) {
     const arr = tags[cat];
     if (!f?.enabled || !arr?.length) continue;
     const count = Math.ceil((arr.length * (f.sliderValue ?? 100)) / 100);
-    arr.slice(0, count).forEach(t => all.add(t));
+    arr.slice(0, count).forEach(t => {
+      const clean = sanitizeYouTubeTag(t);
+      if (clean) all.add(clean);
+    });
   }
   return Array.from(all).join(', ');
 }

--- a/server.js
+++ b/server.js
@@ -2409,6 +2409,49 @@ app.get('/internal-api/youtube/authStatus', (req, res) => {
   });
 });
 
+// Validate YouTube tokens by attempting a real refresh against Google.
+// Used by the client to detect invalid_grant before the user attempts an upload.
+async function _validateYouTubeTokensHandler(req, res) {
+  try {
+    logger?.info?.("🔐 [POST /youtube/validateTokens] Hit");
+    const bodyTokens = req.body?.tokens;
+    const sessionTokens = req.session?.youtubeAuth?.tokens;
+    const tokens = bodyTokens || sessionTokens;
+    if (!tokens || (!tokens.refresh_token && !tokens.access_token)) {
+      logger?.info?.(`🔐 validateTokens: no tokens (bodyTokens=${!!bodyTokens}, sessionTokens=${!!sessionTokens})`);
+      return res.status(200).json({ valid: false, reason: 'no_tokens' });
+    }
+    logger?.info?.(`🔐 validateTokens: attempting refresh (has_refresh=${!!tokens.refresh_token}, has_access=${!!tokens.access_token})`);
+    if (!oauth2Client) {
+      return res.status(200).json({ valid: false, reason: 'oauth_client_unavailable' });
+    }
+    // Use a temp client so we don't mutate global state
+    const tempClient = new google.auth.OAuth2(
+      process.env.GCP_CLIENT_ID,
+      process.env.GCP_CLIENT_SECRET,
+      oauth2Client.redirectUri || getYouTubeRedirectUrl?.()
+    );
+    tempClient.setCredentials(tokens);
+    try {
+      if (tokens.refresh_token) {
+        await tempClient.refreshAccessToken();
+      } else {
+        await tempClient.getAccessToken();
+      }
+      return res.status(200).json({ valid: true });
+    } catch (err) {
+      const msg = (err?.response?.data?.error) || err?.message || 'unknown';
+      const desc = err?.response?.data?.error_description || '';
+      return res.status(200).json({ valid: false, reason: String(msg), description: String(desc) });
+    }
+  } catch (err) {
+    console.error('validateTokens error:', err?.message || err);
+    return res.status(500).json({ valid: false, reason: 'server_error' });
+  }
+}
+app.post('/youtube/validateTokens', _validateYouTubeTokensHandler);
+app.post('/internal-api/youtube/validateTokens', _validateYouTubeTokensHandler);
+
 // Clear YouTube authentication
 app.post('/youtube/clearAuth', (req, res) => {
   logger.info("🧹 [POST /youtube/clearAuth] Hit");


### PR DESCRIPTION
Tag generation & YouTube uploads

- Added sanitizeYouTubeTag() in musicMetadata.js that strips <, >, quotes, control chars, and        
embedded commas/semicolons, then trims and caps each tag at 30 chars
- buildTagString() now sanitizes every tag and drops empties
- The upload flow in vinyl-digitizer re-splits the tags input, sanitizes each tag, and accumulates   
only while the 500-char total holds before sending to YouTube

Vinyl-digitizer header / Start Over

- Removed the Project Title input + History button from the header
- Moved the Start Over button into the header in their place
- Deleted the 6 duplicate Start Over buttons from each step's nav bar

Step 4 audio export

- Made the Title cell in the file-preview table editable; edits feed back into filenames, exported   
file names, and FFmpeg metadata

Step 3 waveform editor

- Fixed the scroll-wheel zoom (was bound to a null ref because it tried to attach before Step 3's DOM   mounted); now re-runs on entering Step 3, uses RAF polling for the ref, and captures wheel events   
with { passive: false, capture: true }
- Stabilized the current-time / duration label so the toolbar no longer shifts as digits change;     
tabular-nums on every segment, and the current-time span reserves a ch-based min-width sized to the  
duration string
- Added boundary handles above the waveform: T-shaped handles for shared boundaries (top crossbar    
drags both, leg direction-locks to split into a gap); two separate solo handles once a gap exists.   
Drag math reads peaks.js view range; positions re-render on zoomview.update and ResizeObserver       
- Disabled enableAutoScroll on the peaks zoomview so zooming during playback no longer warps the view   back to the playhead

Step 5 / 6 consolidation

- Merged Step 6 (YouTube Upload) into Step 5 as a collapsible <details> panel "YouTube Upload        
Details"
- Removed Step 6 entirely; the stepper is now 5 steps
- Updated the step !== 6 effect that pre-fills YouTube metadata to fire on Step 5 instead
- Removed the "you can navigate to YouTube Upload while this continues" message

YouTube auth

- Added a /youtube/validateTokens (and /internal-api/...) endpoint that attempts a real refresh      
against Google and returns valid: true/false with the reason
- YouTubeAuth now tracks tokenValidity (unknown / checking / valid / invalid); canAuth is gated on   
validity, so the page only shows "signed in" once verified
- Verification flow: tries getTokens() first to exchange any unredeemed auth code, then POSTs to     
validateTokens
- Exposed verifyTokens on the parent ref so the upload flow can re-trigger it
- On invalid state, the compact panel shows a red banner ("YouTube sign-in is invalid — uploads will 
fail") with a human-readable reason and a "Sign in to YouTube again" button (the redundant "Clear    
stored YouTube auth" was later removed)
- Sign-in now opens in a new tab via window.open with a youtube_auth_popup_flow=1 flag in
localStorage; the original tab listens to the storage event for youtube_auth_code/youtube_tokens and 
auto-re-verifies. The OAuth callback page shows a "Sign-in complete — close this tab" confirmation   
instead of redirecting when in popup flow
- Upload error handler detects invalid_grant/invalid_token/unauthorized_client/401/403, clears stale 
localStorage tokens, triggers verifyTokens(), and shows a structured card with title, explanation,   
bulleted recovery steps, a primary "Sign in to YouTube again" button, and a Dismiss button — plus a  
separate ytErrorCard style for non-auth errors
- Sticky top banner gets a special "sign-in expired" variant for auth failures
- Cleared automatically when the user re-authenticates and canAuth flips true
- Backend logs 🔐 [POST /youtube/validateTokens] Hit and the body/session token presence

Upload-while-rendering

- The Upload-to-YouTube button is now enabled both when a video is rendered and while one is
rendering
- During render with no video yet: clicking toggles autoUploadYt between Queued and not; queued state   shows blue "✓ Queued — will upload when render finishes (XX%)" with a hint underneath; existing     
post-render logic auto-fires the upload

Step renames

- Stepper labels: Input · Tracks · Waveform · Audio · Video
- Card headings: "Step 1: Input", "Step 2: Tracks", "Step 3: Waveform", "Step 4: Audio", "Step 5:    
Video"
- Nav buttons: Next: Tracks → / Next: Waveform → / Next: Audio → / Next: Video → / ← Back to Waveform   / ← Back to Audio

Mobile layout

- Reduced .content padding from 20px to 8px on mobile, and .contentBody vertical to 4px
- Reduced vinyl-digitizer .page/.header/.stepBar/.card padding on mobile and dropped their left/right   borders + corner radii so they go edge-to-edge
- Removed flex-direction: column from .body on mobile
- Stepper on mobile: labels visible again (font-size 0.7rem, ellipsis truncation), items use flex: 1 
1 0 for even distribution, .stepCircle and .stepLine flex-shrink: 0 so numbers/connectors always     
render, .stepBar clips overflow instead of scrolling

Step 1 multi-file upload & tables

- handleDrop now accepts multiple audio + image files; handleFileInput accepts multiple
- Recording also appends to allAudioFiles
- allAudioFiles accumulates every uploaded audio file (dedup by name:size)
- First dropped image is auto-set as embedArtFile (FLAC art) in addition to going into videoImages   
- Added bottom-of-Step-1 audio files table: # / Filename / Size / Length (HH:MM:SS via new formatHMS)   / Status / × — duration filled in asynchronously via a metadata-only HTMLAudioElement
- Added bottom-of-Step-1 image files table: Thumbnail / Filename / Size / Resolution (W × H captured 
during thumbnail generation) / Status / ×
- Filename cell: native browser tooltip (title) on hover + click to toggle a .filenameCellExpanded   
class that wraps full text
- Per-file loading indicators: each image gets added immediately with loading: true and a dashed     
placeholder + spinner; updates to thumbnail + "✓ Ready" when createThumbnail resolves; audio shows   
"Loading…" only for the actively-decoding file
- Replaced the old green ✅ file-info row with a single "✅ All files loaded" banner that appears      ─────────────────────────────────────────────────────────────────────────────────────────────────────  once everything is ready
- Drop zone hint text updated to mention images
- stopPropagation in handleDrop to prevent the page-level + drop-zone-level handlers both firing     
- Removed a broken inner-state-dedupe that revoked blob URLs synchronously before the functional     
setVideoImages updater ran (caused ERR_FILE_NOT_FOUND / broken thumbnails); replaced with a single   
pre-loop filter against current state + the current batch

Step 2 audio picker

- Picker uses allAudioFiles (not just the latest drop)
- New audioPickConfirmed flag; resets on every Step 1 entry so the picker re-prompts whenever the    
user goes back; "Confirm selection" and "Skip editing" both set the flag

Step 3 audio switcher

- When more than one audio file is uploaded, a pill-style chip row above the toolbar lets the user   
switch which file is loaded in the waveform editor; clicking a non-active chip with existing track   
markers prompts a confirm before swapping

Dark mode on /vinyl-digitizer

- One-line layout fix: removed the pathname !== '/vinyl-digitizer' exclusion that prevented the      
darkContent class from being applied. The 281 existing :global(.darkContent) .xyz rules in
vinyl-digitizer.module.css now apply, so the sidebar toggle affects the whole route
placeholder + spinner; updates to thumbnail + "✓ Ready" when createThumbnail resolves; audio shows   
"Loading…" only for the actively-decoding file
- Replaced the old green ✅ file-info row with a single "✅ All files loaded" banner that appears      once everything is ready
once everything is ready
- Drop zone hint text updated to mention images
- stopPropagation in handleDrop to prevent the page-level + drop-zone-level handlers both firing     
- Removed a broken inner-state-dedupe that revoked blob URLs synchronously before the functional     
setVideoImages updater ran (caused ERR_FILE_NOT_FOUND / broken thumbnails); replaced with a single   
pre-loop filter against current state + the current batch

Step 2 audio picker

- Picker uses allAudioFiles (not just the latest drop)
- New audioPickConfirmed flag; resets on every Step 1 entry so the picker re-prompts whenever the    
user goes back; "Confirm selection" and "Skip editing" both set the flag

Step 3 audio switcher

- When more than one audio file is uploaded, a pill-style chip row above the toolbar lets the user   
switch which file is loaded in the waveform editor; clicking a non-active chip with existing track   
markers prompts a confirm before swapping

Dark mode on /vinyl-digitizer

- One-line layout fix: removed the pathname !== '/vinyl-digitizer' exclusion that prevented the      
darkContent class from being applied. The 281 existing :global(.darkContent) .xyz rules in
vinyl-digitizer.module.css now apply, so the sidebar toggle affects the whole route

CSS additions

- .timeCurrent / .timeSep / .timeDuration, .zoomviewWrap / .boundaryOverlay / .boundaryHandle /      
.boundaryBar / .boundaryLeg (+ split direction variants and solo variant), .ytDetailsBlock /
.ytDetailsSummary, .ytAuthErrorCard / .ytErrorCard (titles, body, list, primary/secondary buttons,   
dark variants), .audioPickerCard family, .audioSwitcher family, .uploadedFilesSection /
.rowActiveFile / .activeBadge / .uploadedThumb / .uploadedThumbPlaceholder / .fileStatusLoading /    
.fileStatusReady / .fileStatusIdle / .fileInfoAllReady, .filenameCellExpanded / .timeCell, plus      
dark-mode variants throughout