### PR TITLE
Riptag faster edits

### DIFF
--- a/app/(main)/riptag/page.js
+++ b/app/(main)/riptag/page.js
@@ -127,6 +127,83 @@ const clampMotionSpeed = (v) => {
   return Math.min(MOTION_SPEED_MAX, Math.max(MOTION_SPEED_MIN, n));
 };
 const STILL_FPS = 2;           // frame rate for motionless slideshows
+
+// The ffmpeg core is ~32 MB. It was fetched and turned into blob URLs on every
+// single render — once per batch video — which is the bulk of the wait before
+// anything starts happening. The URLs stay valid for the life of the page, so
+// build them once and hand the same pair to every FFmpeg instance. (Each render
+// still gets its own FFmpeg worker; only the core download is shared.)
+const FFMPEG_CORE_BASE = "https://unpkg.com/@ffmpeg/core@0.12.6/dist/umd";
+let ffmpegCorePromise = null;
+function loadFFmpegCore() {
+  if (!ffmpegCorePromise) {
+    ffmpegCorePromise = (async () => ({
+      coreURL: await toBlobURL(`${FFMPEG_CORE_BASE}/ffmpeg-core.js`, "text/javascript"),
+      wasmURL: await toBlobURL(`${FFMPEG_CORE_BASE}/ffmpeg-core.wasm`, "application/wasm"),
+    }))();
+    // A failed fetch must not poison every later render.
+    ffmpegCorePromise.catch(() => { ffmpegCorePromise = null; });
+  }
+  return ffmpegCorePromise;
+}
+
+// Downscaled copies of source images, reused across renders: a batch re-renders
+// the same image once per track, and repeated renders of one project redo the
+// identical work. Weakly keyed on the source File so nothing is pinned.
+const downscaleCache = new WeakMap(); // File -> Map<maxDim, result>
+
+// Re-encoding to PNG was the slow half of preparing an image for the encoder —
+// canvas PNG encoding is slow and the result is large for ffmpeg to read back.
+// Photographic sources go out as high-quality JPEG instead; PNG sources stay
+// PNG so any transparency survives.
+async function computeDownscale(file, maxDim) {
+  const isPng = /png/i.test(file.type || "") || /\.png$/i.test(file.name || "");
+  const outType = isPng ? "image/png" : "image/jpeg";
+  const quality = isPng ? undefined : 0.92;
+  const ext = isPng ? "png" : "jpg";
+
+  const draw = (source, nw, nh) => new Promise((resolve) => {
+    if (!nw || !nh || Math.max(nw, nh) <= maxDim) {
+      resolve({ file, resized: false, original: { w: nw, h: nh } });
+      return;
+    }
+    const scale = maxDim / Math.max(nw, nh);
+    const w = Math.max(1, Math.round(nw * scale));
+    const h = Math.max(1, Math.round(nh * scale));
+    const canvas = document.createElement("canvas");
+    canvas.width = w; canvas.height = h;
+    canvas.getContext("2d").drawImage(source, 0, 0, w, h);
+    canvas.toBlob((blob) => {
+      if (!blob) { resolve({ file, resized: false, original: { w: nw, h: nh } }); return; }
+      const newName = file.name.replace(/(\.[^.]+)?$/, `_resized_${w}x${h}.${ext}`);
+      resolve({
+        file: new File([blob], newName, { type: outType }),
+        resized: true, original: { w: nw, h: nh }, resizedTo: { w, h },
+      });
+    }, outType, quality);
+  });
+
+  // Off-thread decode, so a huge scan doesn't freeze the tab mid-render.
+  if (typeof createImageBitmap === "function") {
+    let bmp = null;
+    try { bmp = await createImageBitmap(file); } catch { bmp = null; }
+    if (bmp) {
+      try { return await draw(bmp, bmp.width, bmp.height); }
+      finally { try { bmp.close(); } catch {} }
+    }
+  }
+  return new Promise((resolve) => {
+    const url = URL.createObjectURL(file);
+    const img = new Image();
+    img.onload = async () => {
+      const out = await draw(img, img.naturalWidth, img.naturalHeight);
+      URL.revokeObjectURL(url);
+      resolve(out);
+    };
+    img.onerror = () => { URL.revokeObjectURL(url); resolve({ file, resized: false }); };
+    img.src = url;
+  });
+}
 const BG_DRIFT_ZOOM = 1.2;     // blur bg is scaled this much larger so it has room to drift
 const BG_DRIFT_AMOUNT = 0.06;  // drift travel, as a fraction of the output size
 const BG_DRIFT_PERIOD = 24;    // seconds for one full drift cycle
@@ -231,6 +308,25 @@ function wrapOverlayLines(ctx, text, maxWidth) {
   return lines;
 }
 
+// Output resolution multiplier, shared by both render modes. h264 needs even
+// dimensions and every mode clamps the same way, so the maths lives in one
+// place rather than once per render path.
+const RENDER_SCALES = [0.25, 0.33, 0.5, 0.75, 1, 1.25, 1.5, 2];
+const RENDER_MAX_DIM = 7680;
+const scaleDimension = (n, scale) => {
+  const v = Math.min(RENDER_MAX_DIM, Math.max(2, Math.round(n * (Number(scale) || 1))));
+  return Math.max(2, Math.floor(v / 2) * 2);
+};
+
+// One list of text-overlay modes for both the Text Overlay section and the
+// batch settings panel. The same choice used to be offered through two
+// different controls in two different places, which is why they could disagree.
+const TEXT_MODE_OPTIONS = [
+  { value: "track", label: "Song name (changes per track)" },
+  { value: "custom", label: "Custom text (same throughout)" },
+  { value: "off", label: "No text" },
+];
+
 // Draws the overlay onto an already-sized 2D context. Used both for the
 // on-page preview and for the transparent PNG fed to FFmpeg — one code path so
 // the two can never drift apart.
@@ -300,6 +396,9 @@ function renderOverlayPngFile(text, o, w, h, name) {
 }
 
 const loadImageElement = (src) => new Promise((resolve, reject) => {
+  // An image that is still being processed has no object URL yet. Without this
+  // the src becomes the string "null" and the browser fetches /null (a 404).
+  if (!src) { reject(new Error("loadImageElement: no source")); return; }
   const im = new Image();
   im.onload = () => resolve(im);
   im.onerror = reject;
@@ -582,17 +681,21 @@ export default function RipTagPage() {
   const [textPreviewTrackIdx, setTextPreviewTrackIdx] = useState(null);
   const [textPreviewBusy, setTextPreviewBusy] = useState(false);
   const textPreviewCanvasRef = useRef(null);
+  const concatPreviewCanvasRef = useRef(null);
   // When on, the output resolution tracks the image the video opens with (the
   // pinned image of the first track, else the first selected image) instead of
   // being set by hand. Batch renders take it per-video, from each track's image.
   const [autoMatchImageRes, setAutoMatchImageRes] = useState(false);
-  // Batch render: one video per track, each with that track's image.
+  // Resolution multiplier applied to whatever the resolution works out to.
+  // Shared by the concat render and the batch, so the two modes can't quietly
+  // produce different sizes from the same project.
+  const [renderScale, setRenderScale] = useState(1);
+  // Batch render: one video per track, each with that track's image. Only the
+  // genuinely batch-only choices live here — resolution mode, scale and the
+  // text overlay are shared with the concat render (see sharedTextMode /
+  // resolutionMode / renderScale below).
   const [batchSettings, setBatchSettings] = useState({
     scope: "selected",        // "selected" = every selected track | "pinned" = only tracks with a pinned image
-    resolution: "auto",       // "auto" = match each track's image | "fixed" = use the Video Settings resolution
-    scale: 1,                 // multiplier applied to every batch video's resolution
-    textMode: "track",        // "off" | "track" (song title) | "custom"
-    customText: "",
     nameTemplate: "%num% - %title%",
   });
   const [showBatchSettings, setShowBatchSettings] = useState(false);
@@ -616,6 +719,9 @@ export default function RipTagPage() {
   // keeps memory under iOS Safari's per-tab limit. Playback/export still use
   // the original-quality file via the <audio> element.
   const decodedBufferRef = useRef(null);
+  // Set when decoding the current file threw, so anything waiting on
+  // decodedBufferRef stops waiting instead of hanging until its timeout.
+  const decodeFailedRef = useRef(false);
   const segmentTimerRef = useRef(null);
   const audioRef = useRef(null);
   const audioUrlRef = useRef(null);
@@ -869,7 +975,7 @@ export default function RipTagPage() {
       selectedVideoAudios, selectedVideoImages,
       videoOutputName, ytUploadData, ytTitleVariation, ytTimestampFormat,
       ytTimestampSeparator, ytIncludeTrackNums, ytDescSuffix, ytTitleSuggestions,
-      autoUploadYt, autoMatchImageRes, batchSettings, trackTextOverrides,
+      autoUploadYt, autoMatchImageRes, renderScale, batchSettings, trackTextOverrides,
       exportedTracks, videoImages, droppedAudioFiles]);
 
   // Persist in-flight work when the tab goes away.
@@ -1090,6 +1196,10 @@ export default function RipTagPage() {
     setCurrentTime(0);
     setIsPlaying(false);
     setExportedTracks([]);
+    // Drop the previous file's waveform buffer immediately — otherwise a fast
+    // switch to Step 3 would render the old file's waveform.
+    decodedBufferRef.current = null;
+    decodeFailedRef.current = false;
     // Destroy existing peaks instance
     if (peaksRef.current) {
       peaksRef.current.destroy();
@@ -1146,6 +1256,7 @@ export default function RipTagPage() {
         setChannelData(mono);
         setMessage(`Loaded: ${audioFile.name} (${formatTime(durationSec)})`);
       } catch (err) {
+        decodeFailedRef.current = true;
         setMessage("Error decoding audio: " + err.message);
         setIsLoadingWaveform(false);
         setWaveformLoadStatus("");
@@ -1366,6 +1477,17 @@ export default function RipTagPage() {
     try {
       const Peaks = (await import('peaks.js')).default;
 
+      const getAudioContext = () => {
+        if (!audioContextRef.current || audioContextRef.current.state === 'closed') {
+          const Ctx = window.AudioContext || window.webkitAudioContext;
+          audioContextRef.current = new Ctx();
+        }
+        return audioContextRef.current;
+      };
+      const webAudio = decodedBufferRef.current
+        ? { audioBuffer: decodedBufferRef.current }
+        : { audioContext: getAudioContext() };
+
       const options = {
         zoomview: {
           container: zoomviewRef.current,
@@ -1378,9 +1500,11 @@ export default function RipTagPage() {
         // webAudio.audioBuffer makes peaks.js build the waveform from this
         // buffer instead of fetching + decoding the media element again (a
         // second full-resolution decode was a primary cause of iOS crashes).
-        webAudio: {
-          audioBuffer: decodedBufferRef.current,
-        },
+        // If the decode hasn't finished (or failed), hand peaks.js a real
+        // AudioContext instead and let it decode the media itself — a webAudio
+        // object with neither is what raised "The webAudio.audioContext option
+        // must be a valid AudioContext" and left Step 3 with no waveform.
+        webAudio,
         zoomLevels: [256, 512, 1024, 2048, 4096, 8192, 16384, 32768, 65536],
         segmentOptions: {
           overlay: true,
@@ -1405,11 +1529,12 @@ export default function RipTagPage() {
         Peaks.init(options, (err, peaksInstance) => {
           if (err) {
             console.error('peaks.js init error:', err);
-            // Retry without webAudio if we get "illegal path" or similar errors
-            if (String(err).includes('illegal') || String(err.message || '').includes('illegal') || String(err).includes('not-allowed')) {
-              console.log('Retrying peaks.js init without webAudio...');
-              const fallbackOptions = { ...options };
-              delete fallbackOptions.webAudio;
+            // Retry once by letting peaks.js decode the media through an
+            // AudioContext. Deleting webAudio outright isn't a fallback —
+            // peaks.js then has no source at all and fails again.
+            if (options.webAudio.audioBuffer) {
+              console.log('Retrying peaks.js init with an AudioContext...');
+              const fallbackOptions = { ...options, webAudio: { audioContext: getAudioContext() } };
               Peaks.init(fallbackOptions, (retryErr, retryInstance) => {
                 if (retryErr) { reject(retryErr); return; }
                 peaksRef.current = retryInstance;
@@ -1564,6 +1689,18 @@ export default function RipTagPage() {
         await new Promise(r => setTimeout(r, 50));
         if (cancelled) { setIsLoadingWaveform(false); setWaveformLoadStatus(""); return; }
       }
+      // Wait for the decode effect to produce the waveform AudioBuffer.
+      // Entering Step 3 while a long rip is still decoding used to init
+      // peaks.js with an empty webAudio option, which failed outright.
+      if (!decodedBufferRef.current && !decodeFailedRef.current) {
+        setWaveformLoadStatus("Decoding audio data…");
+        const deadline = Date.now() + 120000;
+        while (!decodedBufferRef.current && !decodeFailedRef.current && Date.now() < deadline) {
+          await new Promise(r => setTimeout(r, 100));
+          if (cancelled) { setIsLoadingWaveform(false); setWaveformLoadStatus(""); return; }
+        }
+      }
+
       // Brief extra delay to ensure audio is ready
       await new Promise(r => setTimeout(r, 200));
 
@@ -2047,11 +2184,10 @@ export default function RipTagPage() {
 
   // ---- FFmpeg ----
   const loadFFmpeg = async () => {
-    const base = "https://unpkg.com/@ffmpeg/core@0.12.6/dist/umd";
     const ff = ffmpegRef.current;
     ff.on("log", ({ message: msg }) => { logOutputRef.current += msg + "\n"; });
     ff.on("progress", ({ progress: p }) => setProgress(p));
-    await ff.load({ coreURL: await toBlobURL(`${base}/ffmpeg-core.js`, "text/javascript"), wasmURL: await toBlobURL(`${base}/ffmpeg-core.wasm`, "application/wasm") });
+    await ff.load(await loadFFmpegCore());
     setLoaded(true);
   };
 
@@ -2406,7 +2542,13 @@ export default function RipTagPage() {
   const safePlay = () => {
     if (!audioRef.current) return;
     const p = audioRef.current.play();
-    if (p && p.catch) p.catch(() => {});
+    // A rejected play() used to be swallowed while isPlaying stayed true, so
+    // the button showed "pause" over silent audio and the next press only
+    // paused an already-paused element.
+    if (p && p.catch) p.catch((err) => {
+      if (err?.name !== 'AbortError') console.warn('audio play() failed:', err);
+      setIsPlaying(false);
+    });
   };
 
   // ---- Track Preview ----
@@ -2432,8 +2574,11 @@ export default function RipTagPage() {
   };
 
   const togglePlay = () => {
-    if (!audioRef.current) return;
-    if (isPlaying) { stopPreview(); }
+    const el = audioRef.current;
+    if (!el) return;
+    // Read the element rather than isPlaying — the flag can drift out of sync
+    // with actual playback, and then the first press does nothing audible.
+    if (!el.paused) { stopPreview(); }
     else { safePlay(); setIsPlaying(true); }
   };
 
@@ -2458,29 +2603,63 @@ export default function RipTagPage() {
   };
 
   // ---- Video Image Helpers ----
-  const createThumbnail = (file, maxSize = 160) => {
+  // Longest edge of the on-screen preview image. Big enough for the overlay
+  // preview canvas, small enough to decode in a few milliseconds.
+  const PREVIEW_MAX_DIM = 1600;
+
+  // Produces the 160px table thumbnail and a display-sized preview from a
+  // single decode. Two things used to make dropping a large image feel like a
+  // hang: the file was decoded on the main thread, and previewUrl pointed at
+  // the original, so every preview redraw decoded the full-resolution image
+  // again. Neither is true now.
+  const createThumbnail = async (file, maxSize = 160) => {
+    const scaleToUrl = (source, sw, sh, limit, type, quality) => new Promise((done) => {
+      const s = Math.min(limit / sw, limit / sh, 1);
+      const w = Math.max(1, Math.round(sw * s));
+      const h = Math.max(1, Math.round(sh * s));
+      const canvas = document.createElement("canvas");
+      canvas.width = w;
+      canvas.height = h;
+      canvas.getContext("2d").drawImage(source, 0, 0, w, h);
+      canvas.toBlob((blob) => done(blob ? URL.createObjectURL(blob) : null), type, quality);
+    });
+
+    const build = async (source, sw, sh) => {
+      const thumbUrl = await scaleToUrl(source, sw, sh, maxSize, "image/jpeg", 0.7);
+      // Only re-encode when there's something to save — a small image is
+      // cheaper shown as-is. webp so a transparent PNG keeps its alpha.
+      const previewUrl = Math.max(sw, sh) > PREVIEW_MAX_DIM
+        ? await scaleToUrl(source, sw, sh, PREVIEW_MAX_DIM, "image/webp", 0.85)
+        : null;
+      return {
+        thumbUrl: thumbUrl || URL.createObjectURL(file),
+        previewUrl: previewUrl || URL.createObjectURL(file),
+        width: sw, height: sh,
+      };
+    };
+
+    // createImageBitmap decodes off the main thread, so the tab stays
+    // responsive while a 60-megapixel scan is being read.
+    if (typeof createImageBitmap === "function") {
+      let bmp = null;
+      try { bmp = await createImageBitmap(file); } catch { bmp = null; }
+      if (bmp) {
+        try { return await build(bmp, bmp.width, bmp.height); }
+        finally { try { bmp.close(); } catch {} }
+      }
+    }
+
     return new Promise((resolve) => {
       const img = new Image();
       const url = URL.createObjectURL(file);
-      img.onload = () => {
-        const naturalWidth = img.width;
-        const naturalHeight = img.height;
-        const scale = Math.min(maxSize / img.width, maxSize / img.height, 1);
-        const w = Math.round(img.width * scale);
-        const h = Math.round(img.height * scale);
-        const canvas = document.createElement('canvas');
-        canvas.width = w;
-        canvas.height = h;
-        canvas.getContext('2d').drawImage(img, 0, 0, w, h);
+      img.onload = async () => {
+        const out = await build(img, img.width, img.height);
         URL.revokeObjectURL(url);
-        canvas.toBlob((blob) => {
-          const thumbUrl = blob ? URL.createObjectURL(blob) : URL.createObjectURL(file);
-          resolve({ thumbUrl, width: naturalWidth, height: naturalHeight });
-        }, 'image/jpeg', 0.7);
+        resolve(out);
       };
       img.onerror = () => {
         URL.revokeObjectURL(url);
-        resolve({ thumbUrl: URL.createObjectURL(file), width: 0, height: 0 });
+        resolve({ thumbUrl: URL.createObjectURL(file), previewUrl: URL.createObjectURL(file), width: 0, height: 0 });
       };
       img.src = url;
     });
@@ -2511,8 +2690,7 @@ export default function RipTagPage() {
       // Add a placeholder entry immediately so the row appears with a spinner
       setVideoImages(prev => [...prev, { id, file: f, thumbUrl: null, previewUrl: null, loading: true, width: 0, height: 0, stretchToFit: false, useBlurBg: true, paddingColor: "#000000", motion: "none", motionSpeed: 1, bgMotion: "none", bgMotionSpeed: 1 }]);
       setSelectedVideoImages(prev => { const next = new Set(prev); next.add(id); return next; });
-      const { thumbUrl, width, height } = await createThumbnail(f);
-      const previewUrl = URL.createObjectURL(f);
+      const { thumbUrl, previewUrl, width, height } = await createThumbnail(f);
       // Step 1's table reads width/height; step 5 (and the memory estimate,
       // "Match image" resolution, and Image Settings oversize count) reads
       // naturalWidth/naturalHeight. Write both so neither silently sees zero.
@@ -2883,6 +3061,31 @@ export default function RipTagPage() {
     setVideoHeight(String(img.naturalHeight));
   }, [autoMatchImageRes, autoMatchSourceImage]);
 
+  // ---- Settings shared by both render modes ---------------------------------
+  // The concat render and the batch used to keep their own copies of the
+  // resolution mode, the scale and the text overlay, so the same project could
+  // be set two ways at once. These are the single source of truth; both panels
+  // read and write them, and both panels show the same value.
+  //
+  // "auto" means the image decides the size: the opening image for the concat
+  // render, each track's own image for the batch.
+  const resolutionMode = autoMatchImageRes ? "auto" : "fixed";
+  // "off" | "track" | "custom" — the enable switch and the text source folded
+  // into one control, matching what the batch panel always offered.
+  const sharedTextMode = textOverlay.enabled ? textOverlay.source : "off";
+  const setSharedTextMode = (mode) => setTextOverlay(o => ({
+    ...o,
+    enabled: mode !== "off",
+    // Keep the last real source when switching off, so turning it back on
+    // returns to what the user had chosen.
+    source: mode === "off" ? o.source : mode,
+  }));
+  // Final output size of the concat render, scale included.
+  const concatDimensions = {
+    w: scaleDimension(parseInt(videoWidth) || 1920, renderScale),
+    h: scaleDimension(parseInt(videoHeight) || 1080, renderScale),
+  };
+
   // Cumulative [start,end) span of every ordered audio track on the video
   // timeline, used to caption segments with the track that's playing.
   const getAudioSpans = (orderedAudios) => {
@@ -2983,17 +3186,24 @@ export default function RipTagPage() {
   };
 
   // Reproduces the render's letterbox / stretch / blur-background compositing on
-  // a canvas so the preview frame matches the encoded one.
-  const drawOverlayPreview = async () => {
-    const canvas = textPreviewCanvasRef.current;
-    const img = overlayPreviewImage();
-    if (!canvas || !img) return;
-    const w = parseInt(videoWidth) || 1920, h = parseInt(videoHeight) || 1080;
+  // a canvas so the preview frame matches the encoded one. Both previews — the
+  // Text Overlay one and the small one under the Render Concat button — go
+  // through here, so neither can drift from the other or from the encoder.
+  const paintFramePreview = async (canvas, { img, text, overlay, outW, outH, maxWidth }) => {
+    if (!canvas) return;
+    // Everything drawTextOverlay does is a percentage of the frame, so shrinking
+    // the canvas keeps the composition identical at a fraction of the pixels.
+    const shrink = maxWidth ? Math.min(1, maxWidth / outW) : 1;
+    const w = Math.max(2, Math.round(outW * shrink));
+    const h = Math.max(2, Math.round(outH * shrink));
     canvas.width = w; canvas.height = h;
     const ctx = canvas.getContext("2d");
     ctx.clearRect(0, 0, w, h);
     let im = null;
-    try { im = await loadImageElement(img.previewUrl || img.thumbUrl); } catch { /* draw bg only */ }
+    const src = img?.previewUrl || img?.thumbUrl;
+    if (src) {
+      try { im = await loadImageElement(src); } catch { /* draw bg only */ }
+    }
     if (im) {
       const iw = im.naturalWidth || im.width, ih = im.naturalHeight || im.height;
       const contain = Math.min(w / iw, h / ih);
@@ -3016,7 +3226,54 @@ export default function RipTagPage() {
       ctx.fillStyle = videoBgColor;
       ctx.fillRect(0, 0, w, h);
     }
-    drawTextOverlay(ctx, overlayPreviewText(), textOverlay, w, h);
+    drawTextOverlay(ctx, text, overlay, w, h);
+  };
+
+  const drawOverlayPreview = async () => {
+    const img = overlayPreviewImage();
+    if (!img) return;
+    await paintFramePreview(textPreviewCanvasRef.current, {
+      img,
+      text: overlayPreviewText(),
+      overlay: textOverlay,
+      outW: concatDimensions.w,
+      outH: concatDimensions.h,
+    });
+  };
+
+  // ---- Concat button preview ------------------------------------------------
+  // The frame the concat video opens with: the first image on the timeline,
+  // captioned the way the first track will be. Drawn automatically so the
+  // button underneath it isn't the only description of what it produces.
+  const concatPreviewImage = (() => {
+    const first = rowTimings[0];
+    const img = first ? videoImages.find(im => im.id === first.id) : null;
+    return img || videoImages.find(im => selectedVideoImages.has(im.id)) || null;
+  })();
+
+  const concatPreviewFrame = () => {
+    const firstAudio = getOrderedAudios()[0];
+    if (!textOverlay.enabled) return { text: "", overlay: textOverlay };
+    if (textOverlay.source === "custom") return { text: textOverlay.customText, overlay: textOverlay };
+    if (!firstAudio) return { text: "", overlay: textOverlay };
+    return {
+      text: trackCaptionText(firstAudio._trackIdx, firstAudio.title),
+      overlay: { ...textOverlay, position: trackCaptionPosition(firstAudio._trackIdx) },
+    };
+  };
+
+  const drawConcatPreview = async () => {
+    const canvas = concatPreviewCanvasRef.current;
+    if (!canvas) return;
+    const { text, overlay } = concatPreviewFrame();
+    await paintFramePreview(canvas, {
+      img: concatPreviewImage,
+      text,
+      overlay,
+      outW: concatDimensions.w,
+      outH: concatDimensions.h,
+      maxWidth: 420,
+    });
   };
 
   const runOverlayPreview = async () => {
@@ -3042,7 +3299,28 @@ export default function RipTagPage() {
     })();
     return () => { cancelled = true; };
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [showTextPreview, textOverlay, textPreviewImgId, textPreviewTrackIdx, videoWidth, videoHeight, videoBgColor, videoImages, exportedTracks, trackClips, videoAudioOrder, selectedVideoAudios]);
+  }, [showTextPreview, textOverlay, textPreviewImgId, textPreviewTrackIdx, concatDimensions.w, concatDimensions.h, videoBgColor, videoImages, exportedTracks, trackClips, videoAudioOrder, selectedVideoAudios]);
+
+  // Warm the ffmpeg core as soon as the user reaches the export/render steps,
+  // so pressing Render doesn't begin with a 32 MB download.
+  useEffect(() => {
+    if (step < 4) return;
+    loadFFmpegCore().catch(() => {});
+  }, [step]);
+
+  // Redraw the concat preview whenever anything it shows can have changed.
+  useEffect(() => {
+    if (step !== 5) return;
+    let cancelled = false;
+    (async () => {
+      if (typeof document !== "undefined" && document.fonts?.ready) await document.fonts.ready;
+      if (!cancelled) await drawConcatPreview();
+    })();
+    return () => { cancelled = true; };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [step, textOverlay, trackTextOverrides, concatDimensions.w, concatDimensions.h, videoBgColor,
+      videoImages, selectedVideoImages, selectedVideoAudios, videoAudioOrder, exportedTracks,
+      slideshowMode, trackImageAssign, manualImageTimings, loopInterval]);
 
   // True when any *selected* image has a motion effect. Motion forces the render
   // to a real frame rate, so the fps control and the slow-render warning key off it.
@@ -3154,7 +3432,7 @@ export default function RipTagPage() {
   const YT_MAX_DURATION_SEC = 12 * 60 * 60; // 12 hours
 
   const estimateVideoSize = () => {
-    const w = parseInt(videoWidth) || 1920, h = parseInt(videoHeight) || 1080;
+    const { w, h } = concatDimensions;
     const audios = exportedTracks.filter((_, i) => selectedVideoAudios.has(i));
     const totalDur = audios.reduce((s, t) => s + (t.end - t.start), 0);
     if (totalDur <= 0) return null;
@@ -3174,7 +3452,7 @@ export default function RipTagPage() {
   const WASM_MEMORY_LIMIT_MB = 2048;
   const WASM_MEMORY_WARN_MB = 1500;
   const estimateMemoryUsage = () => {
-    const w = parseInt(videoWidth) || 1920, h = parseInt(videoHeight) || 1080;
+    const { w, h } = concatDimensions;
     const selectedImgs = videoImages.filter(img => selectedVideoImages.has(img.id));
     if (selectedImgs.length === 0) return null;
     const parsedMax = imageMaxDim === "auto" ? null : parseInt(imageMaxDim);
@@ -3217,53 +3495,33 @@ export default function RipTagPage() {
   };
 
   // Pre-shrink huge source images: a 7000+ px PNG decodes to >200 MB of RGBA in the wasm heap, which combined with x264's frame buffers exceeds the ~2 GB wasm ceiling.
-  const downscaleImageForRender = (file, maxDim) => new Promise((resolve) => {
-    const url = URL.createObjectURL(file);
-    const img = new Image();
-    img.onload = () => {
-      const { naturalWidth: nw, naturalHeight: nh } = img;
-      if (!nw || !nh || Math.max(nw, nh) <= maxDim) {
-        URL.revokeObjectURL(url);
-        resolve({ file, resized: false, original: { w: nw, h: nh } });
-        return;
-      }
-      const scale = maxDim / Math.max(nw, nh);
-      const w = Math.max(1, Math.round(nw * scale));
-      const h = Math.max(1, Math.round(nh * scale));
-      const canvas = document.createElement("canvas");
-      canvas.width = w; canvas.height = h;
-      const ctx = canvas.getContext("2d");
-      ctx.drawImage(img, 0, 0, w, h);
-      canvas.toBlob((blob) => {
-        URL.revokeObjectURL(url);
-        if (!blob) { resolve({ file, resized: false, original: { w: nw, h: nh } }); return; }
-        const newName = file.name.replace(/(\.[^.]+)?$/, `_resized_${w}x${h}.png`);
-        const newFile = new File([blob], newName, { type: "image/png" });
-        resolve({ file: newFile, resized: true, original: { w: nw, h: nh }, resizedTo: { w, h } });
-      }, "image/png");
-    };
-    img.onerror = () => { URL.revokeObjectURL(url); resolve({ file, resized: false }); };
-    img.src = url;
-  });
+  const downscaleImageForRender = async (file, maxDim) => {
+    let perFile = downscaleCache.get(file);
+    if (perFile?.has(maxDim)) return perFile.get(maxDim);
+    const result = await computeDownscale(file, maxDim);
+    if (!perFile) { perFile = new Map(); downscaleCache.set(file, perFile); }
+    perFile.set(maxDim, result);
+    return result;
+  };
 
   // ---- Video Render ----
-  // Freezes everything the encoder needs into a plain object, with the audio
-  // already resolved to Blobs. A queued job can outlive the project it came
-  // from, so past this point the render must never read component state — the
-  // user may have switched to another project by the time it runs.
-  const buildRenderSpec = async () => {
+  // Freezes everything the encoder needs into a plain object. A queued job can
+  // outlive the project it came from, so past this point the render must never
+  // read component state — the user may have switched to another project by the
+  // time it runs.
+  //
+  // Synchronous on purpose: the audio *bytes* are read later, by resolveSpecAudios
+  // when the job actually starts. Reading them here meant the button did several
+  // seconds of blob I/O before the job (and its progress bar) existed.
+  const buildRenderSpec = () => {
     const audios = getOrderedAudios();
     const images = videoImages.filter(img => selectedVideoImages.has(img.id));
     if (audios.length === 0 || images.length === 0) return null;
-    const resolvedAudios = [];
-    for (const t of audios) {
-      const blob = t.file ? t.file : await (await fetch(t.url)).blob();
-      resolvedAudios.push({
-        title: t.title, name: t.name, blob,
-        start: t.start, end: t.end,
-        clipStart: t.clipStart, clipEnd: t.clipEnd, isClipped: t.isClipped,
-      });
-    }
+    const resolvedAudios = audios.map(t => ({
+      title: t.title, name: t.name, file: t.file, url: t.url,
+      start: t.start, end: t.end,
+      clipStart: t.clipStart, clipEnd: t.clipEnd, isClipped: t.isClipped,
+    }));
     return {
       name: (videoOutputName || projectName || "album").replace(/[^a-zA-Z0-9 _\-]/g, "").trim().replace(/\s+/g, "_") || "album",
       audios: resolvedAudios,
@@ -3276,8 +3534,8 @@ export default function RipTagPage() {
       })),
       timings: attachOverlayText(getEffectiveImageTimings(), audios),
       totalDur: audios.reduce((s, t) => s + (t.end - t.start), 0),
-      w: parseInt(videoWidth) || 1920,
-      h: parseInt(videoHeight) || 1080,
+      w: concatDimensions.w,
+      h: concatDimensions.h,
       bgColor: videoBgColor,
       imageMaxDim,
       motionFps,
@@ -3290,6 +3548,12 @@ export default function RipTagPage() {
       ytMeta: { discogsData, ytTitleVariation, ytTimestampFormat, ytTimestampSeparator, ytIncludeTrackNums, ytDescSuffix },
     };
   };
+
+  // Reads each track's bytes. Deferred to the moment a job starts so a queued
+  // render doesn't pin hundreds of megabytes of audio while it waits its turn.
+  const resolveSpecAudios = (audios) => Promise.all(
+    audios.map(async (t) => ({ ...t, blob: t.file ? t.file : await (await fetch(t.url)).blob() }))
+  );
 
   // Pure with respect to component state: everything comes from `spec`, and all
   // output goes through `ctx` (supplied by the render queue).
@@ -3338,11 +3602,7 @@ export default function RipTagPage() {
           ctx.onProgress(Math.min(1, prog.base + prog.span * Math.min(1, elapsed / prog.dur)));
         }
       });
-      const base = "https://unpkg.com/@ffmpeg/core@0.12.6/dist/umd";
-      await ffV.load({
-        coreURL: await toBlobURL(`${base}/ffmpeg-core.js`, "text/javascript"),
-        wasmURL: await toBlobURL(`${base}/ffmpeg-core.wasm`, "application/wasm"),
-      });
+      await ffV.load(await loadFFmpegCore());
 
       appendVideoLog(`Writing ${selectedAudioList.length} audio + ${selectedImageList.length} image file(s)…`);
 
@@ -3795,7 +4055,7 @@ export default function RipTagPage() {
     selectedVideoImages: [...selectedVideoImages],
     videoOutputName, ytUploadData, ytTitleVariation, ytTimestampFormat,
     ytTimestampSeparator, ytIncludeTrackNums, ytDescSuffix, ytTitleSuggestions,
-    autoUploadYt, autoMatchImageRes, batchSettings, trackTextOverrides,
+    autoUploadYt, autoMatchImageRes, renderScale, batchSettings, trackTextOverrides,
   });
 
   // saveActiveProject is memoized on the blob-bearing state only, so the
@@ -3850,7 +4110,15 @@ export default function RipTagPage() {
     setYtTitleSuggestions(s.ytTitleSuggestions || []);
     if (s.autoUploadYt != null) setAutoUploadYt(s.autoUploadYt);
     if (s.autoMatchImageRes != null) setAutoMatchImageRes(s.autoMatchImageRes);
-    if (s.batchSettings) setBatchSettings(prev => ({ ...prev, ...s.batchSettings }));
+    if (s.batchSettings) {
+      // Projects saved before the two render modes shared their settings kept
+      // scale/resolution/text on batchSettings; carry the scale over and drop
+      // the rest, which now come from the shared controls.
+      const { scale, resolution, textMode, customText, ...batchOnly } = s.batchSettings;
+      setBatchSettings(prev => ({ ...prev, ...batchOnly }));
+      if (s.renderScale == null && scale != null) setRenderScale(scale);
+    }
+    if (s.renderScale != null) setRenderScale(s.renderScale);
     setTrackTextOverrides(s.trackTextOverrides || {});
   };
 
@@ -4045,7 +4313,7 @@ export default function RipTagPage() {
         imgsOut.push({
           id: im.id, file: f,
           thumbUrl: thumb?.thumbUrl || URL.createObjectURL(f),
-          previewUrl: URL.createObjectURL(f),
+          previewUrl: thumb?.previewUrl || URL.createObjectURL(f),
           loading: false,
           naturalWidth: im.naturalWidth ?? thumb?.width, naturalHeight: im.naturalHeight ?? thumb?.height,
           width: im.naturalWidth ?? thumb?.width, height: im.naturalHeight ?? thumb?.height,
@@ -4188,24 +4456,22 @@ export default function RipTagPage() {
     if (!id) return;
     const existing = renderQueue.getJob(id);
     if (existing && (existing.status === "running" || existing.status === "queued")) return;
-    let spec;
-    try {
-      spec = await buildRenderSpec();
-    } catch (e) {
-      setMessage(`Could not prepare the render: ${e?.message || e}`);
-      return;
-    }
+    // Everything but the audio bytes is captured synchronously, so the job —
+    // and its progress bar — exist the instant the button is pressed. Reading
+    // the blobs and saving the project used to happen first, which is what left
+    // the button looking dead for a couple of seconds on a long rip.
+    const spec = buildRenderSpec();
     if (!spec) return;
     setShowVideoLogs(true);
-    // Persist first so the queued job's project is on disk even if the tab is
-    // reloaded before it starts.
-    await saveActiveProject();
     const projectName_ = projectName || "Untitled project";
 
     renderQueue.enqueue({
       projectId: id,
       projectName: projectName_,
-      run: (ctx) => runVideoRender(spec, ctx),
+      run: async (ctx) => {
+        const audios = await resolveSpecAudios(spec.audios);
+        return runVideoRender({ ...spec, audios }, ctx);
+      },
       onSettled: async (settled) => {
         if (settled.status !== "done") {
           if (settled.status === "error" && activeProjectIdRef.current === id) {
@@ -4242,6 +4508,10 @@ export default function RipTagPage() {
         if (autoUploadYtRef.current) setTimeout(() => uploadToYouTube(url), 500);
       },
     });
+
+    // Persist after queueing, not before — on a big project this write takes a
+    // while, and the job is already safely on the queue.
+    await saveActiveProject();
   };
 
   // ---- Batch render: one video per track ------------------------------------
@@ -4271,29 +4541,23 @@ export default function RipTagPage() {
     return raw.replace(/[^a-zA-Z0-9 _\-]/g, "").trim().replace(/\s+/g, "_") || `track_${num}`;
   };
 
-  const BATCH_SCALES = [0.25, 0.33, 0.5, 0.75, 1, 1.25, 1.5, 2];
-  const BATCH_MAX_DIM = 7680;
-
   // Single source of truth for a batch video's output size, so the settings
-  // preview and the encoder can't disagree.
+  // preview and the encoder can't disagree. Resolution mode and scale are the
+  // shared ones, so a batch video is the concat video's size unless its own
+  // image says otherwise.
   const batchDimensionsFor = (img) => {
-    const even = (n) => Math.max(2, Math.floor(n / 2) * 2);
-    const auto = batchSettings.resolution === "auto" && img?.naturalWidth && img?.naturalHeight;
+    const auto = resolutionMode === "auto" && img?.naturalWidth && img?.naturalHeight;
     const baseW = auto ? img.naturalWidth : (parseInt(videoWidth) || 1920);
     const baseH = auto ? img.naturalHeight : (parseInt(videoHeight) || 1080);
-    const scale = Number(batchSettings.scale) || 1;
-    // h264 needs even dimensions; matching an odd-sized source would otherwise
-    // get silently padded by the filtergraph's trailing pad.
-    const apply = (n) => even(Math.min(BATCH_MAX_DIM, Math.max(2, Math.round(n * scale))));
-    return { w: apply(baseW), h: apply(baseH) };
+    return { w: scaleDimension(baseW, renderScale), h: scaleDimension(baseH, renderScale) };
   };
 
   // What a batch video's caption will actually say, after mode + per-track override.
   const batchTextFor = (item) => {
-    if (batchSettings.textMode === "off") return "";
-    if (batchSettings.textMode === "custom") {
+    if (sharedTextMode === "off") return "";
+    if (sharedTextMode === "custom") {
       const o = trackTextOverrides[item.audio._trackIdx];
-      return (o && o.text != null && o.text !== "") ? o.text : batchSettings.customText;
+      return (o && o.text != null && o.text !== "") ? o.text : textOverlay.customText;
     }
     return trackCaptionText(item.audio._trackIdx, item.audio.title);
   };
@@ -4334,7 +4598,7 @@ export default function RipTagPage() {
       // and would just add an encode.
       slideshowMode: "distribute",
       loopInterval,
-      textOverlay: { ...textOverlay, enabled: batchSettings.textMode !== "off" && !!text.trim() },
+      textOverlay: { ...textOverlay, enabled: sharedTextMode !== "off" && !!text.trim() },
       overlayTextVaries: false,
       ytMeta: { discogsData, ytTitleVariation, ytTimestampFormat, ytTimestampSeparator, ytIncludeTrackNums, ytDescSuffix },
     };
@@ -6670,13 +6934,17 @@ export default function RipTagPage() {
               {/* Text overlay — burned into the video over each image */}
               <div className={styles.videoSection}>
                 <h3 className={styles.sectionTitle}>Text Overlay</h3>
-                <label className={styles.videoCheckLabel} style={{ display: "flex", alignItems: "center", gap: 8, fontWeight: 600 }}>
-                  <input
-                    type="checkbox"
-                    checked={textOverlay.enabled}
-                    onChange={e => setTextOverlay(o => ({ ...o, enabled: e.target.checked }))}
-                  />
-                  Overlay text on the image
+                {/* The one text switch for the whole step. The batch panel shows
+                    this same control, bound to this same state, so the concat
+                    render and the batch videos always say the same thing. */}
+                <label className={styles.settingLabel} style={{ maxWidth: 380 }}>
+                  Text on the video
+                  <select className={styles.input} value={sharedTextMode} onChange={e => setSharedTextMode(e.target.value)}>
+                    {TEXT_MODE_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
+                  </select>
+                  <span className={styles.settingHelp}>
+                    Applies to both render modes — the concat video and every batch video.
+                  </span>
                 </label>
                 {!textOverlay.enabled && (
                   <p className={styles.hintText} style={{ marginTop: 6 }}>
@@ -6694,13 +6962,6 @@ export default function RipTagPage() {
                   return (
                     <>
                       <div className={styles.overlayGrid}>
-                        <label className={styles.settingLabel}>
-                          Text source
-                          <select className={styles.input} value={textOverlay.source} onChange={e => set("source")(e.target.value)}>
-                            <option value="track">Song name (changes per track)</option>
-                            <option value="custom">Custom text (same throughout)</option>
-                          </select>
-                        </label>
                         {textOverlay.source === "custom" && (
                           <label className={styles.settingLabel} style={{ gridColumn: "span 2" }}>
                             Custom text
@@ -7055,7 +7316,7 @@ export default function RipTagPage() {
 
               {/* Image Settings — controls how source images are pre-processed before render */}
               {videoImages.length > 0 && (() => {
-                const w = parseInt(videoWidth) || 1920, h = parseInt(videoHeight) || 1080;
+                const { w, h } = concatDimensions;
                 const parsedMax = imageMaxDim === "auto" ? null : parseInt(imageMaxDim);
                 const effectiveMaxDim = parsedMax === 0 ? Infinity
                   : (parsedMax && parsedMax > 0 ? parsedMax : Math.round(Math.max(w, h) * 1.25));
@@ -7223,6 +7484,20 @@ export default function RipTagPage() {
                     </div>
                   </div>
                   <label className={styles.settingLabel}>
+                    Scale — {renderScale}×
+                    <select className={styles.input} value={renderScale}
+                      onChange={e => setRenderScale(parseFloat(e.target.value) || 1)}>
+                      {RENDER_SCALES.map(v => (
+                        <option key={v} value={v}>{v}× {v < 1 ? "(smaller)" : v > 1 ? "(larger)" : "(original)"}</option>
+                      ))}
+                    </select>
+                    <span className={styles.settingHelp}>
+                      Applied on top of the resolution, to the concat render and every batch video — output {concatDimensions.w}×{concatDimensions.h}.
+                      {renderScale < 1 && " Smaller renders are much faster and far less likely to run out of memory."}
+                      {renderScale > 1 && " Upscaling won't add detail and makes each render slower."}
+                    </span>
+                  </label>
+                  <label className={styles.settingLabel}>
                     Background color
                     <input type="color" value={videoBgColor} onChange={e => setVideoBgColor(e.target.value)} style={{ width: 44, height: 34, padding: 2, borderRadius: 4, border: "1px solid #cbd5e0", cursor: "pointer" }} />
                   </label>
@@ -7239,7 +7514,7 @@ export default function RipTagPage() {
                     }}>
                       <div style={{ display: "flex", gap: 16, flexWrap: "wrap" }}>
                         <span>Duration: <strong>{formatTime(est.totalDur)}</strong></span>
-                        <span>Resolution: <strong>{videoWidth}×{videoHeight}</strong></span>
+                        <span>Resolution: <strong>{concatDimensions.w}×{concatDimensions.h}</strong>{renderScale !== 1 && <> ({videoWidth}×{videoHeight} × {renderScale})</>}</span>
                         <span>Est. size: <strong>{est.totalMB < 1024 ? `${est.totalMB.toFixed(0)} MB` : `${(est.totalMB/1024).toFixed(1)} GB`}</strong></span>
                         <span>Upload limit: <strong>{YT_UPLOAD_LIMIT_MB / 1024} GB</strong></span>
                       </div>
@@ -7326,6 +7601,22 @@ export default function RipTagPage() {
                       : `Render Concat (${selectedVideoImages.size} image${selectedVideoImages.size !== 1 ? "s" : ""}, ${selectedVideoAudios.size} track${selectedVideoAudios.size !== 1 ? "s" : ""})`}
                   </button>
                   <span className={styles.renderModeHint}>One video — every track joined end to end, images following the slideshow settings.</span>
+                  {/* Auto-drawn opening frame, so the button shows what it makes. */}
+                  {concatPreviewImage ? (
+                    <figure className={styles.renderModePreview}>
+                      <canvas ref={concatPreviewCanvasRef} className={styles.renderModePreviewCanvas} />
+                      <figcaption className={styles.renderModePreviewCap}>
+                        {concatPreviewImage.loading ? <>Reading {concatPreviewImage.file?.name}…</> : (
+                          <>
+                            Opening frame — {concatDimensions.w}×{concatDimensions.h}
+                            {getOrderedAudios().length > 1 && <>, then {getOrderedAudios().length - 1} more track{getOrderedAudios().length === 2 ? "" : "s"}</>}
+                          </>
+                        )}
+                      </figcaption>
+                    </figure>
+                  ) : (
+                    <div className={styles.renderModePreviewEmpty}>Select an image to see a preview of the first frame.</div>
+                  )}
                 </div>
                 <span className={styles.renderModeOr}>or</span>
                 <div className={styles.renderModeCol}>
@@ -7387,16 +7678,16 @@ export default function RipTagPage() {
                 <ul className={styles.batchSummary}>
                   <li><b>{batchPlan.length}</b> video{batchPlan.length === 1 ? "" : "s"} — one per {batchSettings.scope === "pinned" ? "track that has a pinned image" : "selected track"}</li>
                   <li>Each video is <b>one track&apos;s audio</b> over <b>one still image</b> (its pinned image, or the cycling image if unpinned)</li>
-                  <li>Resolution: {batchSettings.resolution === "auto"
+                  <li>Resolution: {resolutionMode === "auto"
                     ? <b>each video matches its own image</b>
                     : <>fixed at <b>{videoWidth}×{videoHeight}</b></>}
-                    {Number(batchSettings.scale) !== 1 && <>, scaled <b>{batchSettings.scale}×</b></>}</li>
-                  <li>Text: {batchSettings.textMode === "off"
+                    {renderScale !== 1 && <>, scaled <b>{renderScale}×</b></>}</li>
+                  <li>Text: {sharedTextMode === "off"
                     ? <b>none</b>
-                    : batchSettings.textMode === "custom"
-                      ? <>the same custom text on every video — <b>{batchSettings.customText || "(empty — nothing will be drawn)"}</b></>
+                    : sharedTextMode === "custom"
+                      ? <>the same custom text on every video — <b>{textOverlay.customText || "(empty — nothing will be drawn)"}</b></>
                       : <b>each track&apos;s song name</b>}
-                    {batchSettings.textMode !== "off" && (
+                    {sharedTextMode !== "off" && (
                       textOverlay.durationMode === "seconds"
                         ? ` — shown for the first ${textOverlay.durationSeconds}s of each video, styled by the Text Overlay section above`
                         : " — shown for the whole video, styled by the Text Overlay section above"
@@ -7426,49 +7717,51 @@ export default function RipTagPage() {
                             Pin an image to a track in the Audio Tracks table above.
                           </span>
                         </label>
+                        {/* Resolution, scale and text are the same settings the
+                            concat render uses — changing them here changes them
+                            in Video Settings / Text Overlay too, and vice versa. */}
                         <label className={styles.settingLabel}>
                           Video resolution
-                          <select className={styles.input} value={batchSettings.resolution} onChange={e => setB("resolution")(e.target.value)}>
+                          <select className={styles.input} value={resolutionMode} onChange={e => setAutoMatchImageRes(e.target.value === "auto")}>
                             <option value="auto">Match each track&apos;s image</option>
                             <option value="fixed">Fixed — {videoWidth}×{videoHeight}</option>
                           </select>
                           <span className={styles.settingHelp}>
-                            {batchSettings.resolution === "auto"
+                            {resolutionMode === "auto"
                               ? "Each video comes out at its own image's pixel size (rounded to even numbers)."
                               : "Every video uses the size set in Video Settings, letterboxing images that don't fit."}
+                            {" "}Shared with <b>Auto match image</b> in Video Settings.
                           </span>
                         </label>
                         <label className={styles.settingLabel}>
-                          Scale — {batchSettings.scale}×
-                          <select className={styles.input} value={batchSettings.scale}
-                            onChange={e => setB("scale")(parseFloat(e.target.value) || 1)}>
-                            {BATCH_SCALES.map(v => (
+                          Scale — {renderScale}×
+                          <select className={styles.input} value={renderScale}
+                            onChange={e => setRenderScale(parseFloat(e.target.value) || 1)}>
+                            {RENDER_SCALES.map(v => (
                               <option key={v} value={v}>{v}× {v < 1 ? "(smaller)" : v > 1 ? "(larger)" : "(original)"}</option>
                             ))}
                           </select>
                           <span className={styles.settingHelp}>
-                            Applied to every video in the batch, on top of the resolution above.
-                            {batchSettings.scale < 1 && " Smaller renders are much faster and far less likely to run out of memory."}
-                            {batchSettings.scale > 1 && " Upscaling won't add detail and makes each render slower."}
+                            Applied on top of the resolution above. Shared with <b>Scale</b> in Video Settings, so the concat render uses it too.
+                            {renderScale < 1 && " Smaller renders are much faster and far less likely to run out of memory."}
+                            {renderScale > 1 && " Upscaling won't add detail and makes each render slower."}
                           </span>
                         </label>
                         <label className={styles.settingLabel}>
-                          Text on each video
-                          <select className={styles.input} value={batchSettings.textMode} onChange={e => setB("textMode")(e.target.value)}>
-                            <option value="track">Song name (different per video)</option>
-                            <option value="custom">Custom text (same on every video)</option>
-                            <option value="off">No text</option>
+                          Text on the video
+                          <select className={styles.input} value={sharedTextMode} onChange={e => setSharedTextMode(e.target.value)}>
+                            {TEXT_MODE_OPTIONS.map(o => <option key={o.value} value={o.value}>{o.label}</option>)}
                           </select>
                           <span className={styles.settingHelp}>
-                            Font, size, colour, background and position come from the <b>Text Overlay</b> section above — this only chooses what it says.
+                            The same switch as the <b>Text Overlay</b> section above, which is also where font, size, colour, background and position come from.
                           </span>
                         </label>
-                        {batchSettings.textMode === "custom" && (
+                        {sharedTextMode === "custom" && (
                           <label className={styles.settingLabel}>
                             Custom text
-                            <input type="text" className={styles.input} value={batchSettings.customText}
+                            <input type="text" className={styles.input} value={textOverlay.customText}
                               placeholder={projectName || "Your text here"}
-                              onChange={e => setB("customText")(e.target.value)} />
+                              onChange={e => setTextOverlay(o => ({ ...o, customText: e.target.value }))} />
                           </label>
                         )}
                         <label className={styles.settingLabel} style={{ gridColumn: "span 2" }}>
@@ -7495,8 +7788,8 @@ export default function RipTagPage() {
                               {batchPlan.map(item => {
                                 const { w, h } = batchDimensionsFor(item.img);
                                 const ov = trackTextOverrides[item.audio._trackIdx] || {};
-                                const fallbackText = batchSettings.textMode === "custom"
-                                  ? (batchSettings.customText || "")
+                                const fallbackText = sharedTextMode === "custom"
+                                  ? (textOverlay.customText || "")
                                   : (item.audio.title || "");
                                 return (
                                   <tr key={item.orderIdx}>
@@ -7514,7 +7807,7 @@ export default function RipTagPage() {
                                     </td>
                                     <td>{w}×{h}</td>
                                     <td>
-                                      {batchSettings.textMode === "off" ? <span style={{ opacity: 0.5 }}>—</span> : (
+                                      {sharedTextMode === "off" ? <span style={{ opacity: 0.5 }}>—</span> : (
                                         <input
                                           type="text"
                                           className={styles.input}
@@ -7527,7 +7820,7 @@ export default function RipTagPage() {
                                       )}
                                     </td>
                                     <td>
-                                      {batchSettings.textMode === "off" ? <span style={{ opacity: 0.5 }}>—</span> : (
+                                      {sharedTextMode === "off" ? <span style={{ opacity: 0.5 }}>—</span> : (
                                         <select
                                           className={styles.inputSmall}
                                           style={{ width: 130, textAlign: "left" }}
@@ -8204,7 +8497,13 @@ export default function RipTagPage() {
         )}
       </div>
 
-      <audio ref={audioRef} onEnded={() => { setIsPlaying(false); setPreviewingTrack(null); }} preload="auto" />
+      <audio
+        ref={audioRef}
+        onPlay={() => setIsPlaying(true)}
+        onPause={() => setIsPlaying(false)}
+        onEnded={() => { setIsPlaying(false); setPreviewingTrack(null); }}
+        preload="auto"
+      />
     </div>
   );
 }

--- a/app/(main)/riptag/page.js
+++ b/app/(main)/riptag/page.js
@@ -29,32 +29,22 @@ import {
 import * as renderQueue from "./renderQueue";
 
 // ---- Helpers ----
+// The one duration/timestamp format for the whole page: hh:mm:ss once past an
+// hour, mm:ss below it. Minutes never run past 59 — a 5h15m rip reads
+// 05:15:43, not 315:43. Truncates rather than rounds so a displayed time never
+// reads past the point it refers to.
 function formatTime(s) {
-  if (!s || s < 0) return "0:00.00";
-  const m = Math.floor(s / 60);
-  const sec = Math.floor(s % 60);
-  const ms = Math.floor((s % 1) * 100);
-  return `${m}:${sec.toString().padStart(2, "0")}.${ms.toString().padStart(2, "0")}`;
-}
-
-// Format seconds as HH:MM:SS (always shows hours, even if 0)
-function formatHMS(s) {
-  if (s == null || !isFinite(s) || s < 0) return "—";
-  const h = Math.floor(s / 3600);
-  const m = Math.floor((s % 3600) / 60);
-  const sec = Math.floor(s % 60);
-  return `${h.toString().padStart(2, "0")}:${m.toString().padStart(2, "0")}:${sec.toString().padStart(2, "0")}`;
-}
-
-// Format seconds as H:MM:SS when >= 1 hour, otherwise M:SS. Whole seconds.
-function formatClock(s) {
-  const total = Math.max(0, Math.round(s || 0));
+  if (!Number.isFinite(s) || s < 0) return "00:00";
+  const total = Math.floor(s);
   const h = Math.floor(total / 3600);
   const m = Math.floor((total % 3600) / 60);
   const sec = total % 60;
   const p = (n) => n.toString().padStart(2, "0");
-  return h > 0 ? `${h}:${p(m)}:${p(sec)}` : `${m}:${p(sec)}`;
+  return h > 0 ? `${p(h)}:${p(m)}:${p(sec)}` : `${p(m)}:${p(sec)}`;
 }
+
+// Alias kept for the clip panel, which reads and writes the same format.
+const formatClock = formatTime;
 
 // Parse "H:MM:SS", "M:SS", or a plain seconds value into seconds.
 function parseClock(str) {
@@ -66,6 +56,26 @@ function parseClock(str) {
   let sec = 0;
   for (const p of parts) sec = sec * 60 + (parseFloat(p) || 0);
   return Math.max(0, sec);
+}
+
+// Duration from the container header via an <audio> metadata read. Decoding a
+// file just to measure it costs ~6 GB of RAM for a multi-hour rip and throws,
+// which used to leave the track recorded as 0 seconds long.
+function probeAudioDuration(url) {
+  return new Promise((resolve) => {
+    const a = new Audio();
+    let settled = false;
+    const done = (v) => {
+      if (settled) return;
+      settled = true;
+      a.removeAttribute("src");
+      resolve(Number.isFinite(v) && v > 0 ? v : 0);
+    };
+    a.addEventListener("loadedmetadata", () => done(a.duration));
+    a.addEventListener("error", () => done(0));
+    a.preload = "metadata";
+    a.src = url;
+  });
 }
 
 function formatBytes(b) {
@@ -629,6 +639,9 @@ export default function RipTagPage() {
   const [aspectDropdownOpen, setAspectDropdownOpen] = useState(false);
   const aspectDropdownRef = useRef(null);
   const audioDragRef = useRef(null);
+  // Set while a Step 5 audio row is duplicated/removed, so the auto-select
+  // effect below doesn't re-select rows the user had deliberately unchecked.
+  const skipAudioAutoSelectRef = useRef(false);
   const imageDragRef = useRef(null);
   const playbackTimerRef = useRef(null);
   const previewCheckRef = useRef(null);
@@ -843,9 +856,21 @@ export default function RipTagPage() {
     const t = setTimeout(() => { if (!hydratingRef.current) saveActiveProject(); }, 2500);
     return () => clearTimeout(t);
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [mounted, activeProjectId, projectName, step, tracks, trackNames, exportedTracks,
-      videoImages, droppedAudioFiles, discogsData, textOverlay, trackImageAssign,
-      slideshowMode, videoWidth, videoHeight, selectedVideoImages, selectedVideoAudios]);
+    // Every field collectSettings() writes belongs here — anything missing is
+    // silently lost on refresh, because nothing else schedules the save. Clip
+    // ranges were the visible casualty: set a start/end, reload, gone.
+  }, [mounted, activeProjectId, step, audioMode, projectName, discogsUrl, discogsData,
+      discogsInputMode, trackNames, manualTrackCount, tracks, duration,
+      outputFormat, filenameFormat, volumeDb, riaaEnabled,
+      silThresholdDb, silMinDur, silWindowMs, silMinTrackLen, selectedTracks,
+      videoWidth, videoHeight, videoBgColor, imageMaxDim,
+      slideshowMode, loopInterval, motionFps, manualImageTimings,
+      textOverlay, trackImageAssign, videoAudioOrder, trackClips,
+      selectedVideoAudios, selectedVideoImages,
+      videoOutputName, ytUploadData, ytTitleVariation, ytTimestampFormat,
+      ytTimestampSeparator, ytIncludeTrackNums, ytDescSuffix, ytTitleSuggestions,
+      autoUploadYt, autoMatchImageRes, batchSettings, trackTextOverrides,
+      exportedTracks, videoImages, droppedAudioFiles]);
 
   // Persist in-flight work when the tab goes away.
   useEffect(() => {
@@ -1215,6 +1240,7 @@ export default function RipTagPage() {
 
   // Auto-select all exported tracks when entering step 5 and sync order
   useEffect(() => {
+    if (skipAudioAutoSelectRef.current) { skipAudioAutoSelectRef.current = false; return; }
     if (step === 5 && exportedTracks.length > 0) {
       setSelectedVideoAudios(prev => {
         // Select any new tracks that aren't already in the set
@@ -1231,6 +1257,10 @@ export default function RipTagPage() {
 
   // ---- Computed ----
   const trackCount = tracks.length;
+  // Distinct files on disk. A Step 5 copy re-uses its source's blob, so the
+  // download list and the ZIP keep one entry per underlying file. Deduping on
+  // url rather than on the copy flag survives deleting the original row.
+  const exportedFiles = exportedTracks.filter((t, i) => exportedTracks.findIndex(o => o.url === t.url) === i);
 
   // Sync track names when track count changes
   useEffect(() => {
@@ -2351,7 +2381,9 @@ export default function RipTagPage() {
     setMessage("Building ZIP…");
     try {
       const zip = new JSZip();
-      for (const t of exportedTracks) zip.file(t.name, await (await fetch(t.url)).blob());
+      // exportedFiles, not exportedTracks: Step 5 copies point at a file that
+      // is already in the archive.
+      for (const t of exportedFiles) zip.file(t.name, await (await fetch(t.url)).blob());
       const blob = await zip.generateAsync({ type: "blob" });
       const a = document.createElement("a");
       a.href = URL.createObjectURL(blob);
@@ -2504,6 +2536,10 @@ export default function RipTagPage() {
       // decode the file here to determine duration.
       const cacheKey = `${f.name}:${f.size}`;
       let dur = typeof audioDurationMap[cacheKey] === "number" ? audioDurationMap[cacheKey] : 0;
+      // Header read first: instant, and the only thing that works on a
+      // multi-hour file. Decoding is the last resort, for containers whose
+      // header carries no duration.
+      if (!dur) dur = await probeAudioDuration(url);
       if (!dur) {
         try {
           const ctx = new (window.AudioContext || window.webkitAudioContext)();
@@ -2659,16 +2695,89 @@ export default function RipTagPage() {
     });
   };
 
+  // Duplicate an audio row so one long file can be rendered several times with
+  // different clip ranges / images. The copy shares the source's blob (same
+  // url/file, new uid) and is appended to exportedTracks, then slotted into the
+  // display order right below the row it came from — appending keeps every
+  // index-keyed piece of state (clips, pins, selection, order) valid as-is.
+  const duplicateAudioRow = (trackIdx, orderIdx) => {
+    const src = exportedTracks[trackIdx];
+    if (!src) return;
+    const newIdx = exportedTracks.length;
+    skipAudioAutoSelectRef.current = true;
+    setExportedTracks(prev => [...prev, { ...prev[trackIdx], uid: newAssetUid(), copyOf: prev[trackIdx].uid }]);
+    setVideoAudioOrder(prev => {
+      const base = prev.length === exportedTracks.length ? prev : exportedTracks.map((_, i) => i);
+      const next = [...base];
+      const at = next.indexOf(trackIdx) === -1 ? next.length - 1 : (orderIdx ?? next.indexOf(trackIdx));
+      next.splice(at + 1, 0, newIdx);
+      return next;
+    });
+    setSelectedVideoAudios(prev => new Set(prev).add(newIdx));
+    // Carry the source row's per-track settings over, so the copy starts as an
+    // exact duplicate and the user only edits what should differ.
+    const range = getTrackClipRange(trackIdx);
+    if (range?.isClipped) setTrackClips(prev => ({ ...prev, [newIdx]: { start: range.clipStart, end: range.clipEnd } }));
+    setTrackImageAssign(prev => (prev[trackIdx] ? { ...prev, [newIdx]: prev[trackIdx] } : prev));
+    setTrackTextOverrides(prev => (prev[trackIdx] ? { ...prev, [newIdx]: { ...prev[trackIdx] } } : prev));
+    setMessage(`Copied “${src.title || src.name}” — set a different clip range on the copy to render it as its own video.`);
+  };
+
+  // Remove a single audio row. Every piece of Step 5 state is keyed by the
+  // exportedTracks index, so dropping one entry means shifting each key above
+  // it down by one.
+  const removeAudioRow = (trackIdx) => {
+    const t = exportedTracks[trackIdx];
+    if (!t) return;
+    const shift = (i) => (i > trackIdx ? i - 1 : i);
+    const shiftMap = (obj) => {
+      const next = {};
+      for (const [k, v] of Object.entries(obj)) {
+        const i = Number(k);
+        if (i === trackIdx) continue;
+        next[shift(i)] = v;
+      }
+      return next;
+    };
+    const shiftSet = (set) => {
+      const next = new Set();
+      set.forEach(i => { if (i !== trackIdx) next.add(shift(i)); });
+      return next;
+    };
+    // Copies share the source's object URL — only release it once nothing else points at it.
+    if (t.url && !exportedTracks.some((o, i) => i !== trackIdx && o.url === t.url)) {
+      try { URL.revokeObjectURL(t.url); } catch {}
+    }
+    skipAudioAutoSelectRef.current = true;
+    setExportedTracks(prev => prev.filter((_, i) => i !== trackIdx));
+    setVideoAudioOrder(prev => {
+      const base = prev.length === exportedTracks.length ? prev : exportedTracks.map((_, i) => i);
+      return base.filter(i => i !== trackIdx).map(shift);
+    });
+    setSelectedVideoAudios(shiftSet);
+    setExpandedAudioRows(shiftSet);
+    setTrackClips(shiftMap);
+    setTrackImageAssign(shiftMap);
+    setTrackTextOverrides(shiftMap);
+    setTextPreviewTrackIdx(prev => (prev == null ? prev : prev === trackIdx ? null : shift(prev)));
+    setMessage(`Removed “${t.title || t.name}” from the video.`);
+  };
+
   // Effective clip range for a track. Falls back to the full track when no clip is set.
   // Returned start/end are file-relative seconds (each exported track file starts at 0).
   const getTrackClipRange = (trackIdx) => {
     const t = exportedTracks[trackIdx];
     if (!t) return null;
     const fullDur = t.end - t.start;
+    // A file whose length couldn't be read is recorded as 0 seconds. Clamping
+    // against that would snap every clip value the user types back to zero, so
+    // an unknown length means "no upper bound" instead.
+    const known = Number.isFinite(fullDur) && fullDur > 0;
+    const limit = known ? fullDur : Infinity;
     const c = trackClips[trackIdx];
-    const cs = c?.start != null ? Math.max(0, Math.min(fullDur, c.start)) : 0;
-    const ce = c?.end != null ? Math.max(cs, Math.min(fullDur, c.end)) : fullDur;
-    return { fullDur, clipStart: cs, clipEnd: ce, clipDur: ce - cs, isClipped: cs > 0 || ce < fullDur };
+    const cs = c?.start != null ? Math.max(0, Math.min(limit, c.start)) : 0;
+    const ce = c?.end != null ? Math.max(cs, Math.min(limit, c.end)) : Math.max(cs, fullDur);
+    return { fullDur, durKnown: known, clipStart: cs, clipEnd: ce, clipDur: ce - cs, isClipped: cs > 0 || ce < fullDur };
   };
 
   const getOrderedAudios = () => {
@@ -3689,6 +3798,13 @@ export default function RipTagPage() {
     autoUploadYt, autoMatchImageRes, batchSettings, trackTextOverrides,
   });
 
+  // saveActiveProject is memoized on the blob-bearing state only, so the
+  // collectSettings it closed over went stale for everything else — clip
+  // ranges, ordering and captions were written as they had been at the last
+  // re-memo, not as they are now. Refreshed every render, read at save time.
+  const collectSettingsRef = useRef(collectSettings);
+  collectSettingsRef.current = collectSettings;
+
   const applySettings = (s) => {
     if (!s) return;
     if (s.step) setStep(s.step);
@@ -3798,13 +3914,13 @@ export default function RipTagPage() {
         liveKeys.add(key);
         if (sameUid(key, t.uid)) {
           bytes.tracks += t.size || 0;
-          exported.push({ key, uid: t.uid, name: t.name, title: t.title, index: t.index, size: t.size, start: t.start, end: t.end });
+          exported.push({ key, uid: t.uid, copyOf: t.copyOf, name: t.name, title: t.title, index: t.index, size: t.size, start: t.start, end: t.end });
           continue;
         }
         const blob = t.file ? t.file : await (await fetch(t.url)).blob();
         await putBlob(key, blob);
         bytes.tracks += blob.size || 0;
-        exported.push({ key, uid: t.uid, name: t.name, title: t.title, index: t.index, size: blob.size, start: t.start, end: t.end });
+        exported.push({ key, uid: t.uid, copyOf: t.copyOf, name: t.name, title: t.title, index: t.index, size: blob.size, start: t.start, end: t.end });
       }
 
       const images = [];
@@ -3839,7 +3955,7 @@ export default function RipTagPage() {
         name: projectName || "Untitled project",
         createdAt: prev.createdAt || Date.now(),
         updatedAt: Date.now(),
-        settings: settingsOverrides ? { ...collectSettings(), ...settingsOverrides } : collectSettings(),
+        settings: settingsOverrides ? { ...collectSettingsRef.current(), ...settingsOverrides } : collectSettingsRef.current(),
         audioFiles,
         activeAudioName: audioFile?.name || null,
         exportedTracks: exported,
@@ -3860,7 +3976,7 @@ export default function RipTagPage() {
       if (!silent) setProjectBusy("");
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [droppedAudioFiles, exportedTracks, videoImages, projectName, audioFile, tracks, refreshProjects]);
+  }, [droppedAudioFiles, exportedTracks, videoImages, projectName, audioFile, tracks, batchVideos, refreshProjects]);
 
   // Rebuilds live state (Files, object URLs, decoded waveform) from a record.
   const hydrateProject = async (rec) => {
@@ -3908,7 +4024,16 @@ export default function RipTagPage() {
         const blob = await getBlob(t.key);
         if (!blob) continue;
         const file = new File([blob], t.name, { type: blob.type || "audio/flac" });
-        tracksOut.push({ uid: t.uid || newAssetUid(), index: t.index, name: t.name, title: t.title, size: blob.size, start: t.start, end: t.end, url: URL.createObjectURL(blob), file });
+        const url = URL.createObjectURL(blob);
+        // Tracks imported before the header probe existed were stored as 0
+        // seconds long whenever the decode-to-measure step ran out of memory.
+        // Re-read the header so an already-saved long rip repairs itself.
+        let { start, end } = t;
+        if (!(end - start > 0)) {
+          const probed = await probeAudioDuration(url);
+          if (probed > 0) { start = 0; end = probed; }
+        }
+        tracksOut.push({ uid: t.uid || newAssetUid(), copyOf: t.copyOf, index: t.index, name: t.name, title: t.title, size: blob.size, start, end, url, file });
       }
       setExportedTracks(tracksOut);
 
@@ -4173,10 +4298,14 @@ export default function RipTagPage() {
     return trackCaptionText(item.audio._trackIdx, item.audio.title);
   };
 
-  const buildBatchSpec = async (item, total) => {
+  // Everything a batch video needs except its audio blob. Reading the blob is
+  // the slow part (a long rip is hundreds of MB), so it's deferred to when the
+  // job actually starts — see startBatchRender. The rest is captured now, at
+  // click time, so editing the settings mid-batch can't change videos that were
+  // already queued.
+  const buildBatchSpec = (item, total) => {
     const t = item.audio;
     const img = item.img;
-    const blob = t.file ? t.file : await (await fetch(t.url)).blob();
     const dur = t.end - t.start;
     const { w, h } = batchDimensionsFor(img);
     const text = batchTextFor(item);
@@ -4184,7 +4313,7 @@ export default function RipTagPage() {
     return {
       name: batchOutputName(item, total),
       audios: [{
-        title: t.title, name: t.name, blob,
+        title: t.title, name: t.name, file: t.file, url: t.url,
         start: t.start, end: t.end,
         clipStart: t.clipStart, clipEnd: t.clipEnd, isClipped: t.isClipped,
       }],
@@ -4244,25 +4373,23 @@ export default function RipTagPage() {
 
   const startBatchRender = async () => {
     const id = activeProjectIdRef.current;
-    if (!id) return;
+    if (!id) { setMessage("No active project to render into — reload the page if this persists."); return; }
     const plan = buildBatchPlan();
-    if (!plan.length) return;
+    if (!plan.length) { setMessage("Nothing to batch render — select at least one audio track and one image."); return; }
     setShowVideoLogs(true);
     // Drop the previous run's finished/cancelled rows so the progress list shows
     // this batch only — a smaller plan would otherwise leave orphans behind.
     renderQueue.jobsForProject(id)
       .filter(j => j.batch && j.status !== "running" && j.status !== "queued")
       .forEach(j => renderQueue.clear(j.jobId));
-    await saveActiveProject();
+    setMessage(`Queued ${plan.length} video${plan.length === 1 ? "" : "s"} — they render one at a time.`);
 
+    // Enqueue synchronously, before any awaiting: the whole batch shows up in
+    // the progress list the instant the button is pressed. Reading each track's
+    // audio used to happen here first, so on a long rip the button looked dead
+    // for however long that took.
     for (const item of plan) {
-      let spec;
-      try {
-        spec = await buildBatchSpec(item, plan.length);
-      } catch (e) {
-        setMessage(`Could not prepare “${item.audio.title}”: ${e?.message || e}`);
-        continue;
-      }
+      const spec = buildBatchSpec(item, plan.length);
       const jobId = `${id}:batch:${item.orderIdx}`;
       const trackIdx = item.audio._trackIdx;
       renderQueue.enqueue({
@@ -4271,7 +4398,13 @@ export default function RipTagPage() {
         projectName: projectName || "Untitled project",
         label: item.audio.title || `Track ${item.orderIdx + 1}`,
         batch: true,
-        run: (ctx) => runVideoRender(spec, ctx),
+        run: async (ctx) => {
+          const a = spec.audios[0];
+          // Fetched here rather than at queue time so the batch doesn't hold
+          // every track's audio in memory while it waits its turn.
+          const blob = a.file ? a.file : await (await fetch(a.url)).blob();
+          return runVideoRender({ ...spec, audios: [{ ...a, blob }] }, ctx);
+        },
         onSettled: async (settled) => {
           if (settled.status !== "done") return;
           const { blob, size, fileName } = settled.result;
@@ -4302,7 +4435,9 @@ export default function RipTagPage() {
         },
       });
     }
-    setMessage(`Queued ${plan.length} batch render${plan.length === 1 ? "" : "s"}.`);
+    // Persist after queueing, not before — on a big project this write takes a
+    // while and there's no reason to make the user watch a dead button for it.
+    await saveActiveProject();
   };
 
   const downloadBatchVideo = (v) => {
@@ -5880,8 +6015,8 @@ export default function RipTagPage() {
                   {isExporting ? "Exporting…" : `Export ${outputFormat.toUpperCase()} (${selectedTracks.size}/${tracks.length})`}
                 </button>
                 {isExporting && <button className={styles.cancelBtn} onClick={cancelExport}>Cancel</button>}
-                {exportedTracks.length > 0 && (
-                  <button className={styles.zipBtn} onClick={downloadZip}>Download as ZIP ({exportedTracks.length})</button>
+                {exportedFiles.length > 0 && (
+                  <button className={styles.zipBtn} onClick={downloadZip}>Download as ZIP ({exportedFiles.length})</button>
                 )}
               </div>
               <p className={styles.exportHint}>Export audio first before you use it to render a video.</p>
@@ -5895,11 +6030,12 @@ export default function RipTagPage() {
               )}
               {message && <p className={styles.msg}>{message}</p>}
 
-              {/* Exported grid */}
-              {exportedTracks.length > 0 && (
+              {/* Exported grid — copies made in Step 5 share a source file, so
+                  they aren't separate downloads here. */}
+              {exportedFiles.length > 0 && (
                 <div className={styles.exportGrid}>
-                  {exportedTracks.map(t => (
-                    <div key={t.index} className={styles.exportCard}>
+                  {exportedFiles.map(t => (
+                    <div key={t.uid || t.index} className={styles.exportCard}>
                       <div className={styles.exportCardMeta}>
                         <span className={styles.exportNum}>{String(t.index + 1).padStart(2, "0")}</span>
                         <div className={styles.exportCardInfo}>
@@ -6022,13 +6158,13 @@ export default function RipTagPage() {
                           </th>
                           <th>#</th><th>Title</th><th>Duration</th>
                           <th title="Pin an image to this track. The image then covers exactly this track's start → end on the timeline.">Image</th>
-                          <th style={{width:32}}></th>
+                          <th style={{width:90}}></th>
                         </tr>
                       </thead>
                       <tbody>
                         {(videoAudioOrder.length === exportedTracks.length ? videoAudioOrder : exportedTracks.map((_, i) => i)).map((trackIdx, orderIdx) => {
                           const t = exportedTracks[trackIdx];
-                          const range = getTrackClipRange(trackIdx) || { fullDur: t.end - t.start, clipStart: 0, clipEnd: t.end - t.start, clipDur: t.end - t.start, isClipped: false };
+                          const range = getTrackClipRange(trackIdx) || { fullDur: t.end - t.start, durKnown: t.end - t.start > 0, clipStart: 0, clipEnd: t.end - t.start, clipDur: t.end - t.start, isClipped: false };
                           const isExpanded = expandedAudioRows.has(trackIdx);
                           return (
                             <React.Fragment key={trackIdx}>
@@ -6045,8 +6181,16 @@ export default function RipTagPage() {
                                   <input type="checkbox" checked={selectedVideoAudios.has(trackIdx)} onChange={() => toggleVideoAudio(trackIdx)} />
                                 </td>
                                 <td>{orderIdx + 1}</td>
-                                <td>{t.title}{range.isClipped && <span className={styles.clipBadge} title={`Clipped to ${formatTime(range.clipStart)} – ${formatTime(range.clipEnd)}`}> · clip</span>}</td>
-                                <td>{range.isClipped ? `${formatTime(range.clipDur)} / ${formatTime(range.fullDur)}` : formatTime(range.fullDur)}</td>
+                                <td>
+                                  {t.title}
+                                  {t.copyOf && <span className={styles.copyBadge} title="A copy of another row — same audio file, its own clip range and image"> · copy</span>}
+                                  {range.isClipped && <span className={styles.clipBadge} title={`Clipped to ${formatTime(range.clipStart)} – ${formatTime(range.clipEnd)}`}> · clip</span>}
+                                </td>
+                                <td>
+                                  {!range.durKnown
+                                    ? <span className={styles.durUnknown} title="Couldn't read this file's length from its header. Type a start and end time to clip it anyway.">unknown</span>
+                                    : range.isClipped ? `${formatTime(range.clipDur)} / ${formatTime(range.fullDur)}` : formatTime(range.fullDur)}
+                                </td>
                                 <td onClick={e => e.stopPropagation()}>
                                   {(() => {
                                     const pickable = videoImages.filter(im => selectedVideoImages.has(im.id));
@@ -6083,13 +6227,29 @@ export default function RipTagPage() {
                                   })()}
                                 </td>
                                 <td onClick={e => e.stopPropagation()}>
-                                  <button
-                                    type="button"
-                                    className={styles.expandRowBtn}
-                                    onClick={() => setExpandedAudioRows(prev => { const n = new Set(prev); n.has(trackIdx) ? n.delete(trackIdx) : n.add(trackIdx); return n; })}
-                                    title={isExpanded ? "Hide clip controls" : "Set clip range"}
-                                    aria-label={isExpanded ? "Hide clip controls" : "Set clip range"}
-                                  >{isExpanded ? "▾" : "▸"}</button>
+                                  <div className={styles.rowActions}>
+                                    <button
+                                      type="button"
+                                      className={styles.expandRowBtn}
+                                      onClick={() => duplicateAudioRow(trackIdx, orderIdx)}
+                                      title="Copy this row — same audio file, its own clip range and image, so you can render several videos from one file"
+                                      aria-label="Copy this row"
+                                    >⧉</button>
+                                    <button
+                                      type="button"
+                                      className={`${styles.expandRowBtn} ${styles.removeRowBtn}`}
+                                      onClick={() => removeAudioRow(trackIdx)}
+                                      title="Remove this row from the video"
+                                      aria-label="Remove this row"
+                                    >×</button>
+                                    <button
+                                      type="button"
+                                      className={styles.expandRowBtn}
+                                      onClick={() => setExpandedAudioRows(prev => { const n = new Set(prev); n.has(trackIdx) ? n.delete(trackIdx) : n.add(trackIdx); return n; })}
+                                      title={isExpanded ? "Hide clip controls" : "Set clip range"}
+                                      aria-label={isExpanded ? "Hide clip controls" : "Set clip range"}
+                                    >{isExpanded ? "▾" : "▸"}</button>
+                                  </div>
                                 </td>
                               </tr>
                               {isExpanded && (
@@ -6110,6 +6270,12 @@ export default function RipTagPage() {
                       </tbody>
                     </table>
                   </div>
+                )}
+                {exportedTracks.length > 0 && (
+                  <p className={styles.hintText} style={{ marginTop: 6 }}>
+                    Use ⧉ to copy a row. The copy points at the same audio file but keeps its own clip range,
+                    image and caption — that&apos;s how you get several videos out of one long recording.
+                  </p>
                 )}
                 {exportedTracks.length > 0 && (() => {
                   // A pin whose image was deselected or removed is inert, so only
@@ -6166,51 +6332,7 @@ export default function RipTagPage() {
                       {discogsArtStatus ? "Fetching…" : `Use Discogs Art (${discogsData.images.length})`}
                     </button>
                   )}
-                  <div style={{marginLeft:"auto",display:"flex",alignItems:"center",gap:8,flexWrap:"wrap"}}>
-                    <label className={styles.videoCheckLabel} style={{display:"flex",alignItems:"center",gap:4}}>
-                      Slideshow:
-                      <select className={styles.inputSmall} value={slideshowMode} onChange={e => setSlideshowMode(e.target.value)} style={{minWidth:140}}>
-                        <option value="distribute">Distribute evenly</option>
-                        <option value="loop">Loop / repeat</option>
-                        <option value="per-track">Sync with tracks</option>
-                        <option value="manual">Manual timing</option>
-                      </select>
-                    </label>
-                    {slideshowMode === "loop" && (
-                      <label className={styles.videoCheckLabel} style={{display:"flex",alignItems:"center",gap:4}}>
-                        Every
-                        <input type="number" className={styles.inputSmall} value={loopInterval} onChange={e => setLoopInterval(Math.max(1, parseInt(e.target.value) || 1))} min="1" max="600" style={{width:60}} />
-                        sec
-                      </label>
-                    )}
-                    {/* Bulk motion — per-image motion lives under each image's preview */}
-                    <label className={styles.videoCheckLabel} style={{display:"flex",alignItems:"center",gap:4}}>
-                      Motion (all):
-                      <select className={styles.inputSmall}
-                        value={videoImages.length > 0 && videoImages.every(im => (im.motion || "none") === (videoImages[0].motion || "none")) ? (videoImages[0].motion || "none") : ""}
-                        onChange={e => { const v = e.target.value; if (v) setVideoImages(prev => prev.map(im => ({ ...im, motion: v }))); }}
-                        style={{minWidth:150}}
-                      >
-                        <option value="" disabled>Mixed…</option>
-                        {IMAGE_MOTIONS.map(m => <option key={m.value} value={m.value}>{m.label}</option>)}
-                      </select>
-                    </label>
-                    {anySelectedImageMotion && (
-                      <label className={styles.videoCheckLabel} style={{display:"flex",alignItems:"center",gap:4}} title="Motion has to be encoded at a real frame rate. Lower = much faster render.">
-                        Motion fps:
-                        <select className={styles.inputSmall} value={motionFps} onChange={e => setMotionFps(parseInt(e.target.value) || 24)} style={{width:70}}>
-                          {[12, 15, 24, 30].map(f => <option key={f} value={f}>{f}</option>)}
-                        </select>
-                      </label>
-                    )}
-                  </div>
                 </div>
-                {anySelectedImageMotion && (
-                  <p className={styles.hintText} style={{marginTop:6}}>
-                    Motion effects encode every frame at {motionFps} fps instead of 2 — expect a noticeably longer render.
-                    {slideshowMode === "loop" && " In loop mode only one cycle is encoded and then repeated, so this stays cheap."}
-                  </p>
-                )}
                 {/* Discogs art fetch progress */}
                 {discogsArtStatus && (
                   <div className={styles.imageStatusBar}>
@@ -6230,6 +6352,52 @@ export default function RipTagPage() {
                     </div>
                     <span className={styles.imageStatusCount}>{imageLoadingStatus.loaded}/{imageLoadingStatus.total}</span>
                   </div>
+                )}
+                {/* Timing / motion controls — these drive the columns below, so they
+                    sit directly on top of the table rather than off in the button row. */}
+                <div className={styles.slideshowBar}>
+                  <label className={styles.videoCheckLabel} style={{display:"flex",alignItems:"center",gap:4}}>
+                    Slideshow:
+                    <select className={styles.inputSmall} value={slideshowMode} onChange={e => setSlideshowMode(e.target.value)} style={{minWidth:140}}>
+                      <option value="distribute">Distribute evenly</option>
+                      <option value="loop">Loop / repeat</option>
+                      <option value="per-track">Sync with tracks</option>
+                      <option value="manual">Manual timing</option>
+                    </select>
+                  </label>
+                  {slideshowMode === "loop" && (
+                    <label className={styles.videoCheckLabel} style={{display:"flex",alignItems:"center",gap:4}}>
+                      Every
+                      <input type="number" className={styles.inputSmall} value={loopInterval} onChange={e => setLoopInterval(Math.max(1, parseInt(e.target.value) || 1))} min="1" max="600" style={{width:60}} />
+                      sec
+                    </label>
+                  )}
+                  {/* Bulk motion — per-image motion lives under each image's preview */}
+                  <label className={styles.videoCheckLabel} style={{display:"flex",alignItems:"center",gap:4}}>
+                    Motion (all):
+                    <select className={styles.inputSmall}
+                      value={videoImages.length > 0 && videoImages.every(im => (im.motion || "none") === (videoImages[0].motion || "none")) ? (videoImages[0].motion || "none") : ""}
+                      onChange={e => { const v = e.target.value; if (v) setVideoImages(prev => prev.map(im => ({ ...im, motion: v }))); }}
+                      style={{minWidth:150}}
+                    >
+                      <option value="" disabled>Mixed…</option>
+                      {IMAGE_MOTIONS.map(m => <option key={m.value} value={m.value}>{m.label}</option>)}
+                    </select>
+                  </label>
+                  {anySelectedImageMotion && (
+                    <label className={styles.videoCheckLabel} style={{display:"flex",alignItems:"center",gap:4}} title="Motion has to be encoded at a real frame rate. Lower = much faster render.">
+                      Motion fps:
+                      <select className={styles.inputSmall} value={motionFps} onChange={e => setMotionFps(parseInt(e.target.value) || 24)} style={{width:70}}>
+                        {[12, 15, 24, 30].map(f => <option key={f} value={f}>{f}</option>)}
+                      </select>
+                    </label>
+                  )}
+                </div>
+                {anySelectedImageMotion && (
+                  <p className={styles.hintText} style={{marginTop:6}}>
+                    Motion effects encode every frame at {motionFps} fps instead of 2 — expect a noticeably longer render.
+                    {slideshowMode === "loop" && " In loop mode only one cycle is encoded and then repeated, so this stays cheap."}
+                  </p>
                 )}
                 {videoImages.length > 0 && (
                   <div className={styles.tableWrap} style={{ marginTop: 12 }}>
@@ -7063,8 +7231,6 @@ export default function RipTagPage() {
                 {(() => {
                   const est = estimateVideoSize();
                   if (!est) return null;
-                  const durMin = Math.floor(est.totalDur / 60);
-                  const durSec = Math.round(est.totalDur % 60);
                   return (
                     <div style={{ marginTop: 12, padding: "10px 14px", borderRadius: 6, fontSize: "0.82rem",
                       background: est.overLimit ? (darkMode ? "#5a1a1a" : "#fff5f5") : (darkMode ? "#252538" : "#f7fafc"),
@@ -7072,7 +7238,7 @@ export default function RipTagPage() {
                       color: darkMode ? "#fff" : "#2d3748"
                     }}>
                       <div style={{ display: "flex", gap: 16, flexWrap: "wrap" }}>
-                        <span>Duration: <strong>{durMin}:{String(durSec).padStart(2,"0")}</strong></span>
+                        <span>Duration: <strong>{formatTime(est.totalDur)}</strong></span>
                         <span>Resolution: <strong>{videoWidth}×{videoHeight}</strong></span>
                         <span>Est. size: <strong>{est.totalMB < 1024 ? `${est.totalMB.toFixed(0)} MB` : `${(est.totalMB/1024).toFixed(1)} GB`}</strong></span>
                         <span>Upload limit: <strong>{YT_UPLOAD_LIMIT_MB / 1024} GB</strong></span>
@@ -8098,6 +8264,14 @@ function RenderJobLine({ job }) {
   return null;
 }
 
+// Decoding a multi-hour file to draw the clip waveform blocks the main thread
+// for minutes, so anything past this length opens with the waveform off and the
+// text fields ready to type into. The checkbox overrides it either way.
+const WAVEFORM_AUTO_SKIP_SEC = 30 * 60;
+// Remembered per file for the session, so collapsing and re-expanding a row
+// doesn't kick off a decode the user already opted out of.
+const waveformDisabledByUrl = new Map();
+
 // Inline panel for selecting a clip range (start/end) within an already-exported track.
 // The track's file plays from 0 to its full duration; start/end are in file-relative seconds.
 function TrackClipPanel({ track, range, onChange, onReset }) {
@@ -8112,7 +8286,15 @@ function TrackClipPanel({ track, range, onChange, onReset }) {
   const [startText, setStartText] = useState(formatClock(range.clipStart));
   const [endText, setEndText] = useState(formatClock(range.clipEnd));
   const [peaks, setPeaks] = useState(null);      // Float32Array of bar amplitudes
-  const [wfStatus, setWfStatus] = useState("loading"); // loading | ready | error
+  const [wfStatus, setWfStatus] = useState("loading"); // loading | ready | error | off
+  const [wfDisabled, setWfDisabled] = useState(() => {
+    const remembered = waveformDisabledByUrl.get(track.url);
+    return remembered != null ? remembered : range.fullDur > WAVEFORM_AUTO_SKIP_SEC;
+  });
+  const toggleWaveform = (disabled) => {
+    waveformDisabledByUrl.set(track.url, disabled);
+    setWfDisabled(disabled);
+  };
   const [playhead, setPlayhead] = useState(null); // seconds, while previewing
   // Waveform viewport. zoom 1 = whole track; viewStart is the left edge in
   // seconds. Peaks are stored at a much finer resolution than the canvas so
@@ -8121,6 +8303,9 @@ function TrackClipPanel({ track, range, onChange, onReset }) {
   const [viewStart, setViewStart] = useState(0);
 
   const fullDur = range.fullDur;
+  const durKnown = range.durKnown !== false && Number.isFinite(fullDur) && fullDur > 0;
+  const isLongTrack = fullDur > WAVEFORM_AUTO_SKIP_SEC;
+  const clockPlaceholder = fullDur >= 3600 ? "h:mm:ss" : "m:ss";
   const MAX_ZOOM = 200;
   const visDur = fullDur / zoom;
   const clampView = useCallback(
@@ -8159,12 +8344,15 @@ function TrackClipPanel({ track, range, onChange, onReset }) {
   // amplitude bars for the waveform. Low-rate mono keeps memory tiny (same
   // approach as the main decode) and the decoded buffer is released immediately.
   useEffect(() => {
+    if (wfDisabled) { setPeaks(null); setWfStatus("off"); return; }
     let cancelled = false;
+    const abort = new AbortController();
     (async () => {
       try {
         setWfStatus("loading");
-        const resp = await fetch(track.url);
+        const resp = await fetch(track.url, { signal: abort.signal });
         const buf = await resp.arrayBuffer();
+        if (cancelled) return;
         const OfflineCtx = window.OfflineAudioContext || window.webkitOfflineAudioContext;
         const decoded = await new OfflineCtx(1, 1, 8000).decodeAudioData(buf);
         if (cancelled) return;
@@ -8189,8 +8377,11 @@ function TrackClipPanel({ track, range, onChange, onReset }) {
         if (!cancelled) setWfStatus("error");
       }
     })();
-    return () => { cancelled = true; };
-  }, [track.url]);
+    // Aborting only helps while the bytes are still being read — once
+    // decodeAudioData has the buffer it runs to completion — but it does stop a
+    // multi-hundred-megabyte read the moment the user ticks the box.
+    return () => { cancelled = true; abort.abort(); };
+  }, [track.url, wfDisabled]);
 
   // Draw the waveform with the selected clip region highlighted plus the
   // start/end markers and the live playhead.
@@ -8250,8 +8441,11 @@ function TrackClipPanel({ track, range, onChange, onReset }) {
   }, [peaks, start, end, fullDur, playhead, zoom, viewStart]);
 
   const commit = (newStart, newEnd) => {
-    const ns = Math.max(0, Math.min(fullDur, newStart));
-    const ne = Math.max(ns, Math.min(fullDur, newEnd));
+    // With an unreadable duration there is nothing sane to clamp against —
+    // clamping to 0 is what made every typed start time snap back to 0:00.
+    const limit = durKnown ? fullDur : Infinity;
+    const ns = Math.max(0, Math.min(limit, newStart));
+    const ne = Math.max(ns, Math.min(limit, newEnd));
     setStart(ns); setEnd(ne);
     setStartText(formatClock(ns)); setEndText(formatClock(ne));
     if (ns === 0 && ne === fullDur) onReset();
@@ -8328,15 +8522,36 @@ function TrackClipPanel({ track, range, onChange, onReset }) {
   return (
     <div className={styles.clipPanel}>
       <div
-        className={styles.clipWaveWrap}
-        title="Click to move the playhead · scroll to zoom · shift+scroll to pan"
+        className={`${styles.clipWaveWrap} ${wfStatus === "ready" ? "" : styles.clipWaveWrapIdle}`}
+        title={wfStatus === "ready" ? "Click to move the playhead · scroll to zoom · shift+scroll to pan" : undefined}
       >
         {wfStatus === "ready" ? (
           <canvas ref={canvasRef} className={styles.clipWaveCanvas} onClick={onWaveClick} />
         ) : (
           <div className={styles.clipWaveStatus}>
-            {wfStatus === "error" ? "Waveform unavailable" : "Loading waveform…"}
+            {wfStatus === "off" && "Waveform off — type the start and end times below, or scrub the player."}
+            {wfStatus === "error" && "Waveform unavailable"}
+            {wfStatus === "loading" && (
+              <>
+                <span className={styles.spinnerInline} /> Loading waveform…
+                {isLongTrack && " This track is long, so this can take a while — tick “Disable waveform” to skip it."}
+              </>
+            )}
           </div>
+        )}
+      </div>
+      <div className={styles.clipWaveToggleRow}>
+        <label className={styles.clipWaveToggle} title="Drawing the waveform means decoding the whole file, which is slow on multi-hour rips. The start/end fields work either way.">
+          <input type="checkbox" checked={wfDisabled} onChange={e => toggleWaveform(e.target.checked)} />
+          Disable waveform
+        </label>
+        {wfDisabled && isLongTrack && (
+          <span className={styles.clipWaveToggleHint}>Off by default over {Math.round(WAVEFORM_AUTO_SKIP_SEC / 60)} min.</span>
+        )}
+        {!durKnown && (
+          <span className={styles.clipWaveToggleHint}>
+            Track length unknown — start/end still apply, they just aren&apos;t bounded.
+          </span>
         )}
       </div>
       {wfStatus === "ready" && (
@@ -8371,7 +8586,7 @@ function TrackClipPanel({ track, range, onChange, onReset }) {
         <label className={styles.clipField}>
           <span>Start</span>
           <input
-            type="text" inputMode="numeric" placeholder="m:ss"
+            type="text" inputMode="numeric" placeholder={clockPlaceholder}
             value={startText}
             onChange={e => setStartText(e.target.value)}
             onBlur={() => commit(parseClock(startText), end)}
@@ -8382,7 +8597,7 @@ function TrackClipPanel({ track, range, onChange, onReset }) {
         <label className={styles.clipField}>
           <span>End</span>
           <input
-            type="text" inputMode="numeric" placeholder="m:ss"
+            type="text" inputMode="numeric" placeholder={clockPlaceholder}
             value={endText}
             onChange={e => setEndText(e.target.value)}
             onBlur={() => commit(start, parseClock(endText))}
@@ -8391,8 +8606,8 @@ function TrackClipPanel({ track, range, onChange, onReset }) {
           <button type="button" onClick={setEndHere} title="Use current playhead">⏱</button>
         </label>
         <button type="button" className={styles.clipPlayBtn} onClick={playClip}>▶ Preview clip</button>
-        <button type="button" className={styles.clipResetBtn} onClick={() => commit(0, fullDur)} disabled={!range.isClipped}>Reset to full</button>
-        <span className={styles.clipDurLabel}>Clip: {formatClock(end - start)} · Track: {formatClock(fullDur)}</span>
+        <button type="button" className={styles.clipResetBtn} onClick={() => commit(0, fullDur)} disabled={!range.isClipped || !durKnown}>Reset to full</button>
+        <span className={styles.clipDurLabel}>Clip: {formatClock(end - start)} · Track: {durKnown ? formatClock(fullDur) : "unknown"}</span>
       </div>
     </div>
   );

--- a/app/(main)/riptag/page.js
+++ b/app/(main)/riptag/page.js
@@ -405,6 +405,138 @@ const loadImageElement = (src) => new Promise((resolve, reject) => {
   im.src = src;
 });
 
+// ---- Render timing instrumentation ----------------------------------------
+// A render that starts fast and crawls later is the hard one to explain from a
+// raw ffmpeg log: the log says what it is doing but never how fast, and the
+// queue's line cap means the early part has scrolled away by the time it is
+// slow. This records wall-clock per stage, samples the encode rate in short
+// windows while a pass runs, and prints a per-decile breakdown at the end —
+// which is what actually shows *where* a render loses its speed.
+const RENDER_SAMPLE_LOG_MS = 5000;   // how often the live rate line is logged
+const RENDER_SAMPLE_CAP = 20000;     // ceiling on retained samples per pass
+
+const nowMs = () => (typeof performance !== "undefined" && performance.now ? performance.now() : Date.now());
+
+const fmtWall = (ms) => {
+  if (ms < 1000) return `${Math.round(ms)}ms`;
+  if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`;
+  return `${Math.floor(ms / 60000)}m${String(Math.round((ms % 60000) / 1000)).padStart(2, "0")}s`;
+};
+const fmtClock = (sec) => {
+  const s = Math.max(0, Math.round(sec || 0));
+  const h = Math.floor(s / 3600), m = Math.floor((s % 3600) / 60);
+  return h ? `${h}:${String(m).padStart(2, "0")}:${String(s % 60).padStart(2, "0")}`
+           : `${m}:${String(s % 60).padStart(2, "0")}`;
+};
+const pctOf = (part, whole) => whole > 0 ? `${((part / whole) * 100).toFixed(0)}%` : "—";
+
+// Chrome-only, and it does NOT cover the wasm heap ffmpeg actually lives in.
+// Useful as a secondary signal (blob/array accumulation on our side), not as
+// "the" memory number.
+const jsHeapNote = () => {
+  const m = typeof performance !== "undefined" && performance.memory;
+  if (!m?.usedJSHeapSize) return "";
+  return ` · js-heap ${Math.round(m.usedJSHeapSize / 1048576)}MB`;
+};
+
+function createRenderTimer(log) {
+  const t0 = nowMs();
+  let last = t0;
+  const entries = [];   // chronological, {kind: "stage" | "pass", ...}
+  let pass = null;
+
+  const stage = (label) => {
+    const now = nowMs();
+    entries.push({ kind: "stage", label, ms: now - last });
+    log(`⏱ ${label} — ${fmtWall(now - last)} (total ${fmtWall(now - t0)})${jsHeapNote()}`);
+    last = now;
+  };
+
+  const beginPass = (label, mediaDur, note = "") => {
+    const now = nowMs();
+    pass = {
+      kind: "pass", label, mediaDur: mediaDur > 0 ? mediaDur : 0,
+      startedAt: now, endedAt: null, lastLogAt: now,
+      window: { wall: now, media: 0 }, samples: [], maxMedia: 0, lastStatus: "",
+    };
+    entries.push(pass);
+    log(`⏱ ${label}: encoding ${fmtClock(mediaDur)} of media${note ? ` — ${note}` : ""}…`);
+    last = now;
+  };
+
+  // Fed from every `time=` line ffmpeg prints. `status` carries fps/size/speed
+  // off the same line, which is how a slowdown gets correlated with output
+  // growth rather than just observed.
+  const sample = (mediaSec, status) => {
+    if (!pass) return;
+    const now = nowMs();
+    if (mediaSec > pass.maxMedia) pass.maxMedia = mediaSec;
+    if (pass.samples.length < RENDER_SAMPLE_CAP) pass.samples.push({ wall: now - pass.startedAt, media: mediaSec });
+    if (status) pass.lastStatus = status;
+    if (now - pass.lastLogAt < RENDER_SAMPLE_LOG_MS) return;
+    const winSec = (now - pass.window.wall) / 1000;
+    const winRate = winSec > 0 ? (mediaSec - pass.window.media) / winSec : 0;
+    const avgRate = mediaSec / Math.max(0.001, (now - pass.startedAt) / 1000);
+    const pct = pass.mediaDur > 0 ? ` ${((mediaSec / pass.mediaDur) * 100).toFixed(0)}%` : "";
+    log(`⏱ ${pass.label}${pct} — ${fmtClock(mediaSec)}/${fmtClock(pass.mediaDur)} encoded in ${fmtWall(now - pass.startedAt)}`
+      + ` · ${winRate.toFixed(2)}× now, ${avgRate.toFixed(2)}× avg${status ? ` · ${status}` : ""}${jsHeapNote()}`);
+    pass.lastLogAt = now;
+    pass.window = { wall: now, media: mediaSec };
+  };
+
+  const endPass = () => {
+    if (!pass) return;
+    pass.endedAt = nowMs();
+    const wall = pass.endedAt - pass.startedAt;
+    log(`⏱ ${pass.label} finished — ${fmtWall(wall)} for ${fmtClock(pass.maxMedia)} of media `
+      + `(${(pass.maxMedia / Math.max(0.001, wall / 1000)).toFixed(2)}× average)`);
+    last = pass.endedAt;
+    pass = null;
+  };
+
+  // Wall time spent on each 10% band of a pass's media. A render that "gets
+  // slow halfway" shows up here as the later bands costing multiples of the
+  // earlier ones — and if they don't, the slowdown is somewhere else.
+  const deciles = (p) => {
+    if (!p.samples.length || p.mediaDur <= 0) return [];
+    const out = [];
+    let prevWall = 0, i = 0;
+    for (let d = 1; d <= 10; d++) {
+      const target = (p.mediaDur * d) / 10;
+      while (i < p.samples.length && p.samples[i].media < target) i++;
+      if (i >= p.samples.length) break;
+      out.push({ band: `${(d - 1) * 10}-${d * 10}%`, ms: p.samples[i].wall - prevWall });
+      prevWall = p.samples[i].wall;
+    }
+    return out;
+  };
+
+  // Printed last, so it survives the queue's log cap even when ffmpeg has been
+  // chatty enough to push every heartbeat out of the buffer.
+  const summary = () => {
+    if (pass) endPass();
+    const total = nowMs() - t0;
+    log(`⏱ ═══ Render timing — total ${fmtWall(total)} ═══`);
+    for (const e of entries) {
+      if (e.kind === "stage") { log(`⏱   ${e.label}: ${fmtWall(e.ms)} (${pctOf(e.ms, total)})`); continue; }
+      const wall = (e.endedAt || nowMs()) - e.startedAt;
+      log(`⏱   ${e.label}: ${fmtWall(wall)} (${pctOf(wall, total)}) — ${fmtClock(e.maxMedia)} of media `
+        + `at ${(e.maxMedia / Math.max(0.001, wall / 1000)).toFixed(2)}× average`);
+      const bands = deciles(e);
+      if (bands.length > 1) {
+        const fastest = Math.min(...bands.map(b => b.ms)) || 1;
+        for (const b of bands) {
+          log(`⏱     ${b.band.padStart(8)} ${fmtWall(b.ms).padStart(8)}  (${(b.ms / fastest).toFixed(1)}× the fastest band)`);
+        }
+      }
+      if (e.lastStatus) log(`⏱     last ffmpeg status: ${e.lastStatus}`);
+    }
+    log("⏱ ═══ end timing ═══");
+  };
+
+  return { stage, beginPass, sample, endPass, summary };
+}
+
 // ---- Persistence keys ----
 // Projects themselves live in IndexedDB (see riptagStore); localStorage only
 // remembers which one was open and holds the pre-projects autosave blob that
@@ -3567,7 +3699,8 @@ export default function RipTagPage() {
     const { imageMaxDim, motionFps, slideshowMode, loopInterval, textOverlay, overlayTextVaries } = spec;
     const videoBgColor = spec.bgColor;
     let ffV = null;
-    {
+    const timer = createRenderTimer(appendVideoLog);
+    try {
       ffV = new FFmpeg();
       ctx.registerFfmpeg(ffV);
       const oomState = { detected: false, lastSignal: "", encodeCompleted: false };
@@ -3600,9 +3733,20 @@ export default function RipTagPage() {
         if (m && prog.dur > 0) {
           const elapsed = parseInt(m[1]) * 3600 + parseInt(m[2]) * 60 + parseFloat(m[3]);
           ctx.onProgress(Math.min(1, prog.base + prog.span * Math.min(1, elapsed / prog.dur)));
+          // The rest of the same status line carries the rate-bearing fields.
+          // Handing them to the timer is what lets the summary say whether a
+          // slowdown tracks output growth, a frame-rate drop, or neither.
+          const fps = msg.match(/fps=\s*([\d.]+)/)?.[1];
+          const size = msg.match(/L?size=\s*(\S+)/)?.[1];
+          const speed = msg.match(/speed=\s*([\d.]+x)/)?.[1];
+          const q = msg.match(/\sq=\s*(-?[\d.]+)/)?.[1];
+          timer.sample(elapsed, [
+            fps && `fps ${fps}`, q && `q ${q}`, size && `out ${size}`, speed && `ffmpeg ${speed}`,
+          ].filter(Boolean).join(" · "));
         }
       });
       await ffV.load(await loadFFmpegCore());
+      timer.stage("ffmpeg core loaded");
 
       appendVideoLog(`Writing ${selectedAudioList.length} audio + ${selectedImageList.length} image file(s)…`);
 
@@ -3615,6 +3759,8 @@ export default function RipTagPage() {
         audioVfsNames.push(vfsName);
         await ffV.writeFile(vfsName, await fetchFile(t.blob));
       }
+      timer.stage(`wrote ${selectedAudioList.length} audio file(s) — `
+        + `${(selectedAudioList.reduce((sum, t) => sum + (t.blob?.size || 0), 0) / 1048576).toFixed(1)} MB`);
 
       const w = spec.w, h = spec.h;
 
@@ -3630,6 +3776,9 @@ export default function RipTagPage() {
         }
         resizedImageFiles.push(result.file);
       }
+      timer.stage(`prepared ${resizedImageFiles.length} image(s) — `
+        + `${(resizedImageFiles.reduce((sum, f) => sum + (f.size || 0), 0) / 1048576).toFixed(1)} MB, `
+        + `max ${imgMaxDim === Infinity ? "unlimited" : `${imgMaxDim}px`}`);
 
       // Write image files (using resized versions where applicable)
       const imgVfsNames = [];
@@ -3640,6 +3789,7 @@ export default function RipTagPage() {
         imgVfsNames.push(vfsName);
         await ffV.writeFile(vfsName, await fetchFile(f));
       }
+      timer.stage(`wrote ${imgVfsNames.length} image file(s) to the ffmpeg VFS`);
       const n = selectedAudioList.length;
 
       // ---- Slideshow segments ----------------------------------------------
@@ -3662,6 +3812,24 @@ export default function RipTagPage() {
       // Degenerate timings (e.g. manual mode with everything zeroed) must not
       // produce concat=n=0 — fall back to one image for the whole video.
       const allSegments = usableSegments.length ? usableSegments : [{ imgIdx: 0, dur: totalDur, text: "", position: textOverlay.position }];
+      // Segment map, so a slow band in the timing summary can be matched to the
+      // image (and caption) that was on screen at that point in the video. Long
+      // slideshows get the shape instead of every row — hundreds of lines here
+      // would push the summary out of the log buffer.
+      if (allSegments.length <= 40) {
+        let at = 0;
+        allSegments.forEach((seg, i) => {
+          const from = at; at += seg.dur;
+          appendVideoLog(`   seg ${i + 1}/${allSegments.length}: ${fmtClock(from)}–${fmtClock(at)} `
+            + `(${seg.dur.toFixed(1)}s) img${seg.imgIdx}${seg.text ? ` · "${seg.text.slice(0, 40)}"` : ""}`);
+        });
+      } else {
+        const durs = allSegments.map(sg => sg.dur);
+        appendVideoLog(`   ${allSegments.length} segments, `
+          + `${Math.min(...durs).toFixed(1)}–${Math.max(...durs).toFixed(1)}s each, `
+          + `${new Set(allSegments.map(sg => sg.imgIdx)).size} distinct image(s)`);
+      }
+      timer.stage(`built ${allSegments.length} slideshow segment(s)`);
 
       // ---- Text overlays ----------------------------------------------------
       // Each distinct caption is rasterised once, at output resolution, into a
@@ -3692,6 +3860,7 @@ export default function RipTagPage() {
           await ffV.writeFile(vfsName, await fetchFile(pngFile));
           overlayVfsByText.set(k, vfsName);
         }
+        if (uniq.size) timer.stage(`rasterised ${overlayVfsByText.size} text overlay PNG(s) at ${w}×${h}`);
       }
       // A caption with a zero-second window would only add an input and a filter
       // that hides it again, so drop it before it reaches the graph.
@@ -3845,9 +4014,22 @@ export default function RipTagPage() {
       // filter or option — which fails during graph init, before any encoding),
       // fall back to a plain still slideshow and run it again so the user still
       // gets their video.
+      // Shape of the work being handed to ffmpeg. A filtergraph that grows with
+      // the number of segments is a prime suspect for a render that degrades as
+      // it goes, so the numbers go in the log next to the timing.
+      const passShape = (args) => {
+        const inputs = args.filter(a => a === "-i").length;
+        const fi = args.indexOf("-filter_complex");
+        const filterLen = fi >= 0 ? (args[fi + 1] || "").length : 0;
+        return `${inputs} input(s), ${filterLen ? `${filterLen}-char filtergraph` : "no filtergraph"}`;
+      };
+
       const runPass = async (buildArgs, what) => {
         graphState.error = "";
-        let code = await ffV.exec(buildArgs());
+        let args = buildArgs();
+        timer.beginPass(what, prog.dur, passShape(args));
+        let code = await ffV.exec(args);
+        timer.endPass();
         const failed = typeof code === "number" && code !== 0;
         if (failed && graphState.error && motionEnabled) {
           appendVideoLog(`⚠ This FFmpeg build rejected the motion filters — ${graphState.error}`);
@@ -3857,7 +4039,10 @@ export default function RipTagPage() {
           outFps = STILL_FPS;
           graphState.error = "";
           oomState.detected = false; oomState.encodeCompleted = false; oomState.lastSignal = "";
-          code = await ffV.exec(buildArgs());
+          args = buildArgs();
+          timer.beginPass(`${what} (retry without motion)`, prog.dur, passShape(args));
+          code = await ffV.exec(args);
+          timer.endPass();
         }
         return code;
       };
@@ -3997,6 +4182,7 @@ export default function RipTagPage() {
       if (typeof exitCode === "number" && exitCode !== 0 && !oomState.encodeCompleted) {
         throw new Error(`FFmpeg exited with code ${exitCode}. See logs above.`);
       }
+      timer.stage(`read ${(data.byteLength / 1048576).toFixed(1)} MB of output out of the ffmpeg VFS`);
       const blob = new Blob([data.buffer], { type: "video/mp4" });
       appendVideoLog("✓ Done!");
 
@@ -4024,6 +4210,10 @@ export default function RipTagPage() {
         description: autoDesc.slice(0, YT_LIMITS.description),
         tags: autoTags.slice(0, YT_LIMITS.tags),
       };
+    } finally {
+      // Runs on the failure paths too — a render that OOMs halfway is exactly
+      // the one whose timing you want to read.
+      timer.summary();
     }
   };
 
@@ -7954,14 +8144,29 @@ export default function RipTagPage() {
               {/* FFmpeg log output */}
               {videoRenderLogs.length > 0 && (
                 <div className={styles.videoLogWrap}>
-                  <button className={styles.analyzeLogToggle} onClick={() => setShowVideoLogs(v => !v)}>
-                    {showVideoLogs ? "▼" : "▶"} FFmpeg Logs ({videoRenderLogs.length} lines)
-                    {isRenderingVideo && <span className={styles.spinnerInline} style={{ marginLeft: 8 }} />}
-                  </button>
+                  <div className={styles.videoLogHeadRow}>
+                    <button className={styles.analyzeLogToggle} onClick={() => setShowVideoLogs(v => !v)}>
+                      {showVideoLogs ? "▼" : "▶"} FFmpeg Logs ({videoRenderLogs.length} lines)
+                      {isRenderingVideo && <span className={styles.spinnerInline} style={{ marginLeft: 8 }} />}
+                    </button>
+                    {/* The timing summary is the point of the ⏱ lines — make it
+                        one click to get the whole log somewhere readable. */}
+                    <button type="button" className={styles.linkBtn}
+                      onClick={() => {
+                        navigator.clipboard?.writeText(videoRenderLogs.join("\n"))
+                          .then(() => setMessage(`Copied ${videoRenderLogs.length} log lines to the clipboard.`))
+                          .catch(() => setMessage("Could not copy the logs — the browser blocked clipboard access."));
+                      }}>
+                      Copy logs
+                    </button>
+                  </div>
                   {showVideoLogs && (
                     <div className={styles.videoLogBox}>
                       {videoRenderLogs.map((line, i) => (
-                        <div key={i} className={`${styles.videoLogLine} ${line.startsWith("ERROR") ? styles.videoLogError : line.startsWith("✓") ? styles.videoLogDone : ""}`}>{line}</div>
+                        <div key={i} className={`${styles.videoLogLine} ${
+                          line.startsWith("ERROR") ? styles.videoLogError
+                            : line.startsWith("✓") ? styles.videoLogDone
+                            : line.startsWith("⏱") ? styles.videoLogTiming : ""}`}>{line}</div>
                       ))}
                       <div ref={videoLogsEndRef} />
                     </div>

--- a/app/(main)/riptag/renderQueue.js
+++ b/app/(main)/riptag/renderQueue.js
@@ -188,6 +188,21 @@ async function pump() {
   job.progress = 0;
   emit();
 
+  // Let the browser paint the "running" state before the encoder starts. pump()
+  // is called synchronously from enqueue(), which is called from the click
+  // handler, so without this yield the first expensive thing run() does happens
+  // in the same task as the click and the progress bar only appears after it.
+  await new Promise(resolve => setTimeout(resolve, 0));
+  if (job._cancelled) {
+    pumping = false;
+    job._run = null;
+    job.endedAt = job.endedAt || Date.now();
+    emit();
+    try { job._onSettled?.({ status: "cancelled" }, publicView(job)); } catch {}
+    pump();
+    return;
+  }
+
   // Progress and log updates arrive far faster than the UI needs them; batch
   // them onto animation frames so a chatty ffmpeg log can't thrash React.
   let dirty = false;

--- a/app/(main)/riptag/riptag.module.css
+++ b/app/(main)/riptag/riptag.module.css
@@ -4872,6 +4872,20 @@
 .perTrackTextBlock { margin-top: 10px; }
 
 /* ── Paired render modes ── */
+/* Render timing lines stand out from the ffmpeg firehose around them. */
+.videoLogHeadRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+.videoLogTiming {
+  color: #2b6cb0;
+  font-weight: 600;
+  white-space: pre;
+}
+:global(.darkContent) .videoLogTiming { color: #90cdf4; }
+
 .renderModeRow {
   display: flex;
   align-items: flex-start;

--- a/app/(main)/riptag/riptag.module.css
+++ b/app/(main)/riptag/riptag.module.css
@@ -2435,6 +2435,19 @@
   margin-bottom: 4px;
 }
 
+/* Slideshow / motion row — sits directly above the images table it governs. */
+.slideshowBar {
+  display: flex;
+  gap: 10px;
+  align-items: center;
+  flex-wrap: wrap;
+  margin-top: 10px;
+  padding: 8px 10px;
+  border: 1px solid #e2e8f0;
+  border-radius: 6px;
+  background: #f7fafc;
+}
+
 .videoThumb {
   width: 72px;
   height: 54px;
@@ -2850,6 +2863,26 @@
   line-height: 1;
 }
 .expandRowBtn:hover { background: #edf2f7; }
+.rowActions {
+  display: flex;
+  align-items: center;
+  gap: 4px;
+  justify-content: flex-end;
+}
+.removeRowBtn {
+  font-size: 1rem;
+  color: #a0aec0;
+}
+.removeRowBtn:hover {
+  background: #fff5f5;
+  border-color: #fc8181;
+  color: #c53030;
+}
+.copyBadge {
+  font-size: 0.72rem;
+  color: #a0aec0;
+  font-weight: 600;
+}
 .clipPanelRow > td {
   background: #f7fafc;
   border-top: 1px dashed #cbd5e0;
@@ -2884,10 +2917,44 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  gap: 6px;
   width: 100%;
   height: 100%;
+  padding: 0 10px;
+  text-align: center;
   font-size: 0.8rem;
   color: #718096;
+}
+/* No canvas to show — shrink the box so the clip fields sit higher up. */
+.clipWaveWrapIdle {
+  height: 40px;
+  background: #f7fafc;
+}
+.clipWaveToggleRow {
+  display: flex;
+  align-items: center;
+  gap: 10px;
+  flex-wrap: wrap;
+  max-width: 640px;
+}
+.clipWaveToggle {
+  display: flex;
+  align-items: center;
+  gap: 5px;
+  font-size: 0.78rem;
+  color: #4a5568;
+  cursor: pointer;
+  user-select: none;
+}
+.clipWaveToggleHint {
+  font-size: 0.72rem;
+  color: #a0aec0;
+}
+.durUnknown {
+  font-size: 0.78rem;
+  color: #b7791f;
+  border-bottom: 1px dotted #b7791f;
+  cursor: help;
 }
 .clipControlsRow {
   display: flex;
@@ -2952,6 +3019,10 @@
   background: #1a1a2e;
   border-color: #444;
 }
+:global(.darkContent) .clipWaveWrapIdle { background: #202033; }
+:global(.darkContent) .clipWaveToggle { color: #cbd5e0; }
+:global(.darkContent) .clipWaveToggleHint { color: #718096; }
+:global(.darkContent) .durUnknown { color: #ecc94b; border-bottom-color: #ecc94b; }
 :global(.darkContent) .clipWaveStatus { color: #a0aec0; }
 
 :global(.darkContent) .clipBadge { color: #90b0ff; }
@@ -2960,6 +3031,17 @@
   color: #e2e8f0;
 }
 :global(.darkContent) .expandRowBtn:hover { background: #2a2a3d; }
+:global(.darkContent) .removeRowBtn { color: #718096; }
+:global(.darkContent) .removeRowBtn:hover {
+  background: #3d2222;
+  border-color: #c53030;
+  color: #feb2b2;
+}
+:global(.darkContent) .copyBadge { color: #718096; }
+:global(.darkContent) .slideshowBar {
+  background: #252538;
+  border-color: #444;
+}
 :global(.darkContent) .clipPanelRow > td {
   background: #252538;
   border-top-color: #555;

--- a/app/(main)/riptag/riptag.module.css
+++ b/app/(main)/riptag/riptag.module.css
@@ -4892,6 +4892,41 @@
   opacity: 0.75;
   line-height: 1.35;
 }
+/* Auto-drawn first frame under the concat button. */
+.renderModePreview {
+  margin: 2px 0 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.renderModePreviewCanvas {
+  /* Only max constraints, so the canvas keeps its own aspect ratio whether the
+     output is landscape, square or portrait. */
+  display: block;
+  width: auto;
+  height: auto;
+  max-width: 100%;
+  max-height: 220px;
+  margin: 0 auto;
+  border-radius: 4px;
+  border: 1px solid #e2e8f0;
+  background: #f0f0f0;
+}
+:global(.darkContent) .renderModePreviewCanvas { border-color: #444; background: #1b1b26; }
+.renderModePreviewCap {
+  font-size: 0.7rem;
+  opacity: 0.65;
+  line-height: 1.3;
+}
+.renderModePreviewEmpty {
+  font-size: 0.72rem;
+  opacity: 0.55;
+  padding: 14px 10px;
+  text-align: center;
+  border: 1px dashed #cbd5e0;
+  border-radius: 4px;
+}
+:global(.darkContent) .renderModePreviewEmpty { border-color: #444; }
 .renderModeOr {
   align-self: center;
   font-size: 0.75rem;


### PR DESCRIPTION
# RipTag: waveform playback, shared render settings, preview + render performance

Touches `app/(main)/riptag/page.js`, `app/(main)/riptag/renderQueue.js`, `app/(main)/riptag/riptag.module.css`.

## Step 3 — waveform editor playback

- Fixed `Peaks.init(): The webAudio.audioContext option must be a valid AudioContext`. Step 3 initialised peaks.js before the decode effect had produced the waveform `AudioBuffer`, so `webAudio` was handed an empty object — intermittent, and it left the editor with no waveform at all.
- Peaks init now waits for the decoded buffer (bounded, with a "Decoding audio data…" status) and short-circuits if the decode failed.
- `webAudio` is built conditionally: the pre-decoded `audioBuffer` when it's ready, otherwise a real `AudioContext` so peaks.js can decode the media itself.
- The retry path now retries *with* an `AudioContext` instead of deleting `webAudio` outright, which peaks.js rejects for having no source at all.
- The previous file's waveform buffer is cleared on file switch — a fast switch to Step 3 could render the old file's waveform.
- Play/pause: `safePlay()` swallowed rejected `play()` calls while `isPlaying` stayed true, so the button showed ⏸ over silent audio and the next press only paused an already-paused element. It now resets the flag, `togglePlay()` reads `audioRef.current.paused` instead of the state flag, and the `<audio>` element has `onPlay`/`onPause` handlers so the two can't drift.

## Step 5 — one set of render settings for both modes

- The concat render and the batch panel each kept their own copy of the resolution mode, scale and text overlay, so one project could be set two ways at once. They now share state; changing either panel changes both.
  - Text overlay on/off + source → `textOverlay.enabled`/`.source`, surfaced as `sharedTextMode`
  - Custom text → `textOverlay.customText`
  - Resolution mode → `autoMatchImageRes`, surfaced as `resolutionMode`
  - Scale multiplier → new shared `renderScale`
- The overlay-text checkbox is gone. Both places now show the **same** three-option control (Song name / Custom text / No text) from one `TEXT_MODE_OPTIONS` list — "No text" is the off switch, collapsing the old checkbox + separate "Text source" select into a single control that looks identical in both panels.
- Scale is new for the concat render: Video Settings gets the same dropdown, applied to output dimensions, the size/memory estimates and the Image Settings max-dim baseline.
- Each shared control names its twin, so it reads as one setting rather than two.
- `renderScale` is persisted; `applySettings` migrates older projects (their `batchSettings.scale` carries over, the other duplicated fields are dropped).

**Two default shifts**, both a consequence of the merge:
- Batch text used to default to "Song name" regardless of the Text Overlay switch; it now follows that switch, which defaults to off.
- Batch resolution used to default to "match each track's image"; it now follows `autoMatchImageRes`, which defaults to off (fixed at the Video Settings size).

## Step 5 — auto-generated concat preview

- The Render Concat button now has an auto-drawn preview of the frame the video opens with: the first image on the timeline (honouring pins and slideshow order), composited exactly as the encoder will (letterbox / stretch / blur background), with the first track's caption at its effective position. No button to press; it redraws on any relevant change.
- The Text Overlay preview and the new one share a single `paintFramePreview()` helper, so neither can drift from the other or from the render.

## Fixes and performance

- **`GET /null` 404** — a freshly dropped image has no object URL until processing finishes, so the previews called `loadImageElement(null)` and the browser fetched `/null`. `loadImageElement` now rejects on a falsy src and `paintFramePreview` paints background-only instead; the caption reads "Reading *filename*…" meanwhile. This also fixed the same latent bug in the Text Overlay preview.
- **Dropping a large image felt like a hang** — `createThumbnail` decoded the whole file on the main thread, and `previewUrl` pointed at the *original*, so every preview redraw (and the step 5 image row, which renders that URL twice) re-decoded a full-resolution photo. One decode via `createImageBitmap` (off-thread) now yields both the 160px thumbnail and a ≤1600px preview (webp, so alpha survives); images already under that keep the original. The project-restore path uses the same helper.
- **The ffmpeg core was re-downloaded on every render** — ~32 MB of `ffmpeg-core.js` + `.wasm` fetched at the top of `runVideoRender`, once per batch video, plus again for audio export. `loadFFmpegCore()` builds the blob URLs once per page and shares them; a failed fetch clears the cached promise. Each render still gets its own worker.
- **The core is now prefetched** when the user reaches step 4 or 5, so the first Render click doesn't begin with the download.
- **Image prep was re-encoding to PNG, uncached** — slow to encode, large for ffmpeg to read back. `computeDownscale` decodes off-thread and emits JPEG q0.92 for photographic sources (PNG sources stay PNG for transparency), and results are cached in a `WeakMap` keyed on the source `File`, so a batch reusing one image does the work once.
- **Render status appeared a couple of seconds late** — `startRender` fetched every track's audio blob and wrote the whole project to IndexedDB *before* enqueuing, and enqueuing is what shows the bar. `buildRenderSpec` is now synchronous (holding `file`/`url`, not bytes), a new `resolveSpecAudios` reads the blobs inside the job's `run`, and `saveActiveProject()` moved after the enqueue — matching the batch path, which already worked this way. A queued render no longer pins hundreds of MB of audio while it waits.
- `renderQueue.pump()` yields one tick after marking a job running, so the browser paints the status before the encoder takes the main thread (with a cancel check so cancelling in that window settles cleanly instead of running the job anyway).

## Not changed

- x264 settings are untouched. The still path is `-tune stillimage -crf 18` at the default `medium` preset; `-preset veryfast` (already used for 1440p+/motion) would cut encode time several-fold on near-identical frames at slightly larger files — a quality/size call, not free speed.
- Multithreaded ffmpeg isn't available: `@ffmpeg/core-mt` needs `SharedArrayBuffer`, which needs COOP/COEP cross-origin isolation site-wide.
